### PR TITLE
Add yarn.lock to rollup config to allow us to yarn link during local dev

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -97,6 +97,10 @@ export default {
           src: "./CHANGELOG.md",
           dest: "dist",
         },
+        {
+          src: "./yarn.lock", // Allows us to go yarn link path/to/package while doing local dev
+          dest: "dist",
+        },
       ],
     }),
     visualizer({


### PR DESCRIPTION
In order to run yarn link, we need a yarn.lock in the dist folder
