### PR TITLE
Mark messages as read on unscrollable views

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -145,7 +145,8 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
   const [fetchChannelError, setFetchChannelError] = useState<SendbirdError>(null);
 
   // Ref
-  const { scrollRef, scrollPubSub, scrollDistanceFromBottomRef, isScrollBottomReached, setIsScrollBottomReached } = useMessageListScroll();
+  const { scrollRef, scrollPubSub, scrollDistanceFromBottomRef, isScrollBottomReached, setIsScrollBottomReached, isScrollable } =
+    useMessageListScroll();
   const messageInputRef = useRef(null);
 
   const toggleReaction = useToggleReactionCallback(currentChannel, config.logger);
@@ -193,6 +194,17 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
     onChannelUpdated: (channel) => setCurrentChannel(channel),
     logger: config.logger,
   });
+
+  /**
+   * When we initially load a channels messages, useGroupChannelMessages markAsRead will fire.
+   * If the view is unscrollable though, isScrollBottomReached is false. This means the unread messages will not be marked as read.
+   */
+  useEffect(() => {
+    if (isScrollable === null || messageDataSource.loading) return;
+    if (!isScrollable && messageDataSource.messages.length > 0 && !disableMarkAsRead) {
+      markAsReadScheduler.push(currentChannel);
+    }
+  }, [isScrollable, messageDataSource.loading]);
 
   useOnScrollPositionChangeDetectorWithRef(scrollRef, {
     async onReachedTop() {

--- a/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
+++ b/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import pubSubFactory from '../../../../lib/pubSub';
 import { useOnScrollPositionChangeDetectorWithRef } from '../../../../hooks/useOnScrollReachedEndDetector';
 
@@ -38,6 +38,7 @@ export function useMessageListScroll() {
 
   const [scrollPubSub] = useState(() => pubSubFactory<ScrollTopics, ScrollTopicUnion>());
   const [isScrollBottomReached, setIsScrollBottomReached] = useState(false);
+  const [isScrollable, setIsScrollable] = useState<boolean | null>(null);
 
   useLayoutEffect(() => {
     const unsubscribes: { remove(): void }[] = [];
@@ -96,11 +97,18 @@ export function useMessageListScroll() {
     },
   });
 
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    const { scrollHeight, clientHeight } = scrollRef.current;
+    setIsScrollable(scrollHeight > clientHeight);
+  }, [scrollRef.current]);
+
   return {
     scrollRef,
     scrollPubSub,
     isScrollBottomReached,
     setIsScrollBottomReached,
     scrollDistanceFromBottomRef,
+    isScrollable,
   };
 }


### PR DESCRIPTION
See tin.

To describe the issue, useGroupChannelMessages fires on mount, when it receives new messages, it calls:

```
 markAsRead: (channels) => {
      if (!disableMarkAsRead && isScrollBottomReached) {
        channels.forEach((it) => markAsReadScheduler.push(it));
      }
    },
```
    
On the initial fetch, isScrollBottomReached is false. When the scrollView loads and it's position changes 

`useOnScrollPositionChangeDetectorWithRef` fires, and this calls

```
await messageDataSource.loadPrevious();
```

and during this time isScrollBottomReached becomes true. Then, markAsRead is fired again, but this time it clears.

If there are not enough messages to scroll the view, the second fetch is never fired, and the messages stay unread.