### PR TITLE
[APP-6380] - support passing delete message modal

### DIFF
--- a/src/modules/Channel/components/Message/index.tsx
+++ b/src/modules/Channel/components/Message/index.tsx
@@ -34,7 +34,7 @@ const Message = (props: MessageProps): React.ReactElement => {
     localMessages,
   } = useChannelContext();
 
-  const { message } = props;
+  const { message, renderRemoveMessageModal = (props) => <RemoveMessageModal {...props} /> } = props;
 
   return (
     <MessageView
@@ -45,15 +45,13 @@ const Message = (props: MessageProps): React.ReactElement => {
         !initialized || isDisabledBecauseFrozen(currentGroupChannel) || isDisabledBecauseMuted(currentGroupChannel) || !config.isOnline
       }
       shouldRenderSuggestedReplies={
-        config?.groupChannel?.enableSuggestedReplies
-        && (
-          config?.groupChannel?.showSuggestedRepliesFor === 'all_messages'
-            ? true
-            : message.messageId === currentGroupChannel?.lastMessage?.messageId
-        )
+        config?.groupChannel?.enableSuggestedReplies &&
+        (config?.groupChannel?.showSuggestedRepliesFor === 'all_messages'
+          ? true
+          : message.messageId === currentGroupChannel?.lastMessage?.messageId) &&
         // the options should appear only when there's no failed or pending messages
-        && localMessages?.length === 0
-        && getSuggestedReplies(message).length > 0
+        localMessages?.length === 0 &&
+        getSuggestedReplies(message).length > 0
       }
       isReactionEnabled={isReactionEnabled}
       replyType={replyType}
@@ -86,7 +84,7 @@ const Message = (props: MessageProps): React.ReactElement => {
       setAnimatedMessageId={setAnimatedMessageId}
       onMessageAnimated={onMessageAnimated}
       renderFileViewer={(props) => <FileViewer {...props} />}
-      renderRemoveMessageModal={(props) => <RemoveMessageModal {...props} />}
+      renderRemoveMessageModal={renderRemoveMessageModal}
     />
   );
 };

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -42,6 +42,7 @@ export const MessageList = ({
   renderPlaceholderLoader = () => <PlaceHolder type={PlaceHolderTypes.LOADING} />,
   renderPlaceholderEmpty = () => <PlaceHolder className="sendbird-conversation__no-messages" type={PlaceHolderTypes.NO_MESSAGES} />,
   renderFrozenNotification = () => <FrozenNotification className="sendbird-conversation__messages__notification" />,
+  renderRemoveMessageModal,
 }: MessageListProps) => {
   const {
     allMessages,
@@ -69,7 +70,8 @@ export const MessageList = ({
   } = useChannelContext();
 
   const store = useSendbirdStateContext();
-  const allMessagesFiltered = typeof filterMessageList === 'function' ? allMessages.filter(filterMessageList as (message: EveryMessage) => boolean) : allMessages;
+  const allMessagesFiltered =
+    typeof filterMessageList === 'function' ? allMessages.filter(filterMessageList as (message: EveryMessage) => boolean) : allMessages;
   const markAsReadScheduler = store.config.markAsReadScheduler;
 
   const [isScrollBottom, setIsScrollBottom] = useState(false);
@@ -205,6 +207,7 @@ export const MessageList = ({
                     renderMessageContent={renderMessageContent}
                     renderSuggestedReplies={renderSuggestedReplies}
                     renderCustomSeparator={renderCustomSeparator}
+                    renderRemoveMessageModal={renderRemoveMessageModal}
                     // backward compatibility
                     renderMessage={renderMessage}
                   />
@@ -237,11 +240,11 @@ export const MessageList = ({
                 </MessageProvider>
               );
             })}
-            {!hasMoreNext
-              && store?.config?.groupChannel?.enableTypingIndicator
-              && store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
+            {!hasMoreNext &&
+              store?.config?.groupChannel?.enableTypingIndicator &&
+              store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
                 <TypingIndicatorBubble typingMembers={typingMembers} handleScroll={moveScroll} />
-            )}
+              )}
             {/* show frozen notifications, */}
             {/* show new message notifications, */}
           </div>

--- a/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
@@ -8,7 +8,7 @@ import { TypingIndicatorType } from '../../../../types';
 import ConnectionStatus from '../../../../ui/ConnectionStatus';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 
-import type { RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../../types';
+import type { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../../types';
 import type { GroupChannelHeaderProps } from '../GroupChannelHeader';
 import type { GroupChannelMessageListProps } from '../MessageList';
 import type { MessageContentProps } from '../../../../ui/MessageContent';
@@ -81,6 +81,8 @@ export interface GroupChannelUIBasicProps {
    * A function that customizes the rendering of the typing indicator component.
    */
   renderTypingIndicator?: () => React.ReactElement;
+
+  renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void; onSubmit: () => void }) => React.ReactElement;
 }
 
 export interface GroupChannelUIViewProps extends GroupChannelUIBasicProps {
@@ -148,8 +150,8 @@ export const GroupChannelUIView = (props: GroupChannelUIViewProps) => {
       <div className="sendbird-conversation__footer">
         {renderMessageInput?.()}
         <div className="sendbird-conversation__footer__typing-indicator">
-          {renderTypingIndicator?.()
-            || (config?.groupChannel?.enableTypingIndicator && config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Text) && (
+          {renderTypingIndicator?.() ||
+            (config?.groupChannel?.enableTypingIndicator && config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Text) && (
               <TypingIndicator channelUrl={channelUrl} />
             ))}
           {!isOnline && <ConnectionStatus />}

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -53,6 +53,8 @@ export interface MessageProps {
    * @description Customizes all child components of the message.
    * */
   renderMessage?: (props: RenderMessageParamsType) => React.ReactElement;
+
+  renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void; onSubmit: () => void }) => React.ReactElement;
 }
 
 export interface MessageViewProps extends MessageProps {
@@ -79,7 +81,6 @@ export interface MessageViewProps extends MessageProps {
   deleteMessage: (message: CoreMessageType) => Promise<void>;
 
   renderFileViewer: (props: { message: FileMessage; onCancel: () => void }) => React.ReactElement;
-  renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void }) => React.ReactElement;
 
   animatedMessageId: number;
   setAnimatedMessageId: React.Dispatch<React.SetStateAction<number>>;
@@ -100,9 +101,7 @@ const MessageView = (props: MessageViewProps) => {
     renderMessage,
     children,
     renderMessageContent = (props) => <MessageContent {...props} />,
-    renderSuggestedReplies = (props) => (
-      <SuggestedReplies {...props} />
-    ),
+    renderSuggestedReplies = (props) => <SuggestedReplies {...props} />,
     renderCustomSeparator,
     renderEditInput,
     hasSeparator,
@@ -160,7 +159,8 @@ const MessageView = (props: MessageViewProps) => {
   const editMessageInputRef = useRef(null);
   const messageScrollRef = useRef(null);
 
-  const displaySuggestedMentionList = isOnline && isMentionEnabled && mentionNickname.length > 0 && !isDisabledBecauseFrozen(channel) && !isDisabledBecauseMuted(channel);
+  const displaySuggestedMentionList =
+    isOnline && isMentionEnabled && mentionNickname.length > 0 && !isDisabledBecauseFrozen(channel) && !isDisabledBecauseMuted(channel);
 
   const mentionNodes = useDirtyGetMentions({ ref: editMessageInputRef }, { logger });
   const ableMention = mentionNodes?.length < maxUserMentionCount;
@@ -175,7 +175,7 @@ const MessageView = (props: MessageViewProps) => {
           mentionedUserIds.splice(i, 1);
           return true;
         }
-      }),
+      })
     );
   }, [mentionedUserIds]);
 
@@ -203,14 +203,14 @@ const MessageView = (props: MessageViewProps) => {
       timeouts.push(
         setTimeout(() => {
           setIsAnimated(true);
-        }, 500),
+        }, 500)
       );
 
       timeouts.push(
         setTimeout(() => {
           setAnimatedMessageId(null);
           onMessageAnimated?.();
-        }, 1600),
+        }, 1600)
       );
     } else {
       setIsAnimated(false);
@@ -260,16 +260,15 @@ const MessageView = (props: MessageViewProps) => {
           onQuoteMessageClick: onQuoteMessageClick,
           onMessageHeightChange: handleScroll,
         })}
-        { /* Suggested Replies */ }
-        {
-          shouldRenderSuggestedReplies && renderSuggestedReplies({
+        {/* Suggested Replies */}
+        {shouldRenderSuggestedReplies &&
+          renderSuggestedReplies({
             replyOptions: getSuggestedReplies(message),
             onSendMessage: sendUserMessage,
             message,
-          })
-        }
+          })}
         {/* Modal */}
-        {showRemove && renderRemoveMessageModal({ message, onCancel: () => setShowRemove(false) })}
+        {showRemove && renderRemoveMessageModal({ message, onCancel: () => setShowRemove(false), onSubmit: () => deleteMessage(message) })}
         {showFileViewer && renderFileViewer({ message: message as FileMessage, onCancel: () => setShowFileViewer(false) })}
       </>
     );
@@ -346,11 +345,11 @@ const MessageView = (props: MessageViewProps) => {
             }}
             onKeyDown={(e) => {
               if (
-                displaySuggestedMentionList
-                && mentionSuggestedUsers?.length > 0
-                && ((e.key === MessageInputKeys.Enter && ableMention)
-                  || e.key === MessageInputKeys.ArrowUp
-                  || e.key === MessageInputKeys.ArrowDown)
+                displaySuggestedMentionList &&
+                mentionSuggestedUsers?.length > 0 &&
+                ((e.key === MessageInputKeys.Enter && ableMention) ||
+                  e.key === MessageInputKeys.ArrowUp ||
+                  e.key === MessageInputKeys.ArrowDown)
               ) {
                 setMessageInputEvent(e);
                 return true;
@@ -365,18 +364,15 @@ const MessageView = (props: MessageViewProps) => {
 
   return (
     <div
-      className={getClassName([
-        'sendbird-msg-hoc sendbird-msg--scroll-ref',
-        isAnimated ? 'sendbird-msg-hoc__animated' : '',
-      ])}
+      className={getClassName(['sendbird-msg-hoc sendbird-msg--scroll-ref', isAnimated ? 'sendbird-msg-hoc__animated' : ''])}
       style={children || renderMessage ? undefined : { marginBottom: '2px' }}
       data-sb-message-id={message.messageId}
       data-sb-created-at={message.createdAt}
       ref={messageScrollRef}
     >
       {/* date-separator */}
-      {hasSeparator
-        && (renderedCustomSeparator || (
+      {hasSeparator &&
+        (renderedCustomSeparator || (
           <DateSeparator>
             <Label type={LabelTypography.CAPTION_2} color={LabelColors.ONBACKGROUND_2}>
               {format(message.createdAt, stringSet.DATE_FORMAT__MESSAGE_LIST__DATE_SEPARATOR, {

--- a/src/modules/GroupChannel/components/Message/index.tsx
+++ b/src/modules/GroupChannel/components/Message/index.tsx
@@ -34,7 +34,7 @@ export const Message = (props: MessageProps): React.ReactElement => {
     deleteMessage,
   } = useGroupChannelContext();
 
-  const { message } = props;
+  const { message, renderRemoveMessageModal = (props) => <RemoveMessageModal {...props} /> } = props;
   const initialized = !loading && Boolean(currentChannel);
 
   const groupChannelConfig = config?.groupChannel;
@@ -43,9 +43,10 @@ export const Message = (props: MessageProps): React.ReactElement => {
     const { enableSuggestedReplies, showSuggestedRepliesFor } = groupChannelConfig;
     if (!enableSuggestedReplies) return false;
     if (
-      (!showSuggestedRepliesFor || showSuggestedRepliesFor === 'last_message_only')
-      && message.messageId === currentChannel?.lastMessage?.messageId
-    ) return false;
+      (!showSuggestedRepliesFor || showSuggestedRepliesFor === 'last_message_only') &&
+      message.messageId === currentChannel?.lastMessage?.messageId
+    )
+      return false;
     if (getSuggestedReplies(message).length === 0) return false;
     const lastMessage = messages[messages.length - 1];
     if (lastMessage && isSendableMessage(lastMessage) && lastMessage.sendingStatus !== 'succeeded') return false;
@@ -80,7 +81,7 @@ export const Message = (props: MessageProps): React.ReactElement => {
       setAnimatedMessageId={setAnimatedMessageId}
       onMessageAnimated={onMessageAnimated}
       renderFileViewer={(props) => <FileViewer {...props} />}
-      renderRemoveMessageModal={(props) => <RemoveMessageModal {...props} />}
+      renderRemoveMessageModal={renderRemoveMessageModal}
     />
   );
 };

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -51,11 +51,14 @@ export interface GroupChannelMessageListProps {
    * A function that customizes the rendering of a suggested replies component.
    */
   renderSuggestedReplies?: GroupChannelUIBasicProps['renderSuggestedReplies'];
+
+  renderRemoveMessageModal?: GroupChannelUIBasicProps['renderRemoveMessageModal'];
 }
 
 export const MessageList = ({
   className = '',
   renderMessage = (props) => <Message {...props} />,
+  renderRemoveMessageModal,
   renderMessageContent,
   renderSuggestedReplies,
   renderCustomSeparator,
@@ -177,15 +180,16 @@ export const MessageList = ({
                     renderMessageContent,
                     renderSuggestedReplies,
                     renderCustomSeparator,
+                    renderRemoveMessageModal,
                   })}
                 </MessageProvider>
               );
             })}
-            {!hasNext()
-              && store?.config?.groupChannel?.enableTypingIndicator
-              && store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
+            {!hasNext() &&
+              store?.config?.groupChannel?.enableTypingIndicator &&
+              store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
                 <TypingIndicatorBubbleWrapper channelUrl={channelUrl} handleScroll={onMessageContentSizeChanged} />
-            )}
+              )}
           </div>
         </div>
 


### PR DESCRIPTION
Support passing delete message modal

PR description
- pass through renderRemoveMessageModal from `ChannelUI`. This allows consuming apps to supply the delete modal. The original modal will be the default.


