### PR TITLE
Expose channel fetching error

### DIFF
--- a/src/modules/Channel/context/ChannelProvider.tsx
+++ b/src/modules/Channel/context/ChannelProvider.tsx
@@ -105,6 +105,7 @@ interface MessageStoreInterface {
   unreadSince: string;
   unreadSinceDate: Date | null;
   isInvalid: boolean;
+  fetchChannelError: SendbirdError | null;
   currentGroupChannel: Nullable<GroupChannel>;
   hasMorePrev: boolean;
   oldestMessageTimeStamp: number;
@@ -239,6 +240,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
     unreadSince,
     unreadSinceDate,
     isInvalid,
+    fetchChannelError,
     currentGroupChannel,
     hasMorePrev,
     oldestMessageTimeStamp,
@@ -475,6 +477,7 @@ const ChannelProvider: React.FC<ChannelContextProps> = (props: ChannelContextPro
       unreadSince,
       unreadSinceDate,
       isInvalid,
+      fetchChannelError,
       currentGroupChannel,
       hasMorePrev,
       hasMoreNext,

--- a/src/modules/Channel/context/dux/actionTypes.ts
+++ b/src/modules/Channel/context/dux/actionTypes.ts
@@ -1,4 +1,4 @@
-import type { EmojiContainer } from '@sendbird/chat';
+import { SendbirdError, type EmojiContainer } from '@sendbird/chat';
 import type { GroupChannel, Member } from '@sendbird/chat/groupChannel';
 import type { ReactionEvent } from '@sendbird/chat/message';
 
@@ -50,6 +50,7 @@ type CHANNEL_PAYLOAD_TYPES = {
   };
   [FETCH_INITIAL_MESSAGES_FAILURE]: {
     currentGroupChannel: null | GroupChannel;
+    fetchChannelError: SendbirdError;
   };
   [FETCH_PREV_MESSAGES_FAILURE]: {
     currentGroupChannel: null | GroupChannel;

--- a/src/modules/Channel/context/dux/initialState.ts
+++ b/src/modules/Channel/context/dux/initialState.ts
@@ -1,6 +1,6 @@
 import { CoreMessageType, SendableMessageType } from '../../../../utils';
 import { GroupChannel, Member } from '@sendbird/chat/groupChannel';
-import { EmojiContainer } from '@sendbird/chat';
+import { EmojiContainer, SendbirdError } from '@sendbird/chat';
 import type { MessageListParams as MessageListParamsInternal } from '../ChannelProvider';
 
 export interface ChannelInitialStateType {
@@ -12,6 +12,7 @@ export interface ChannelInitialStateType {
   unreadSince: string;
   unreadSinceDate: Date | null;
   isInvalid: boolean;
+  fetchChannelError: SendbirdError | null;
   currentGroupChannel: GroupChannel | null;
   hasMorePrev: boolean;
   oldestMessageTimeStamp: number;
@@ -50,6 +51,7 @@ const initialState: ChannelInitialStateType = {
    */
   unreadSinceDate: null,
   isInvalid: false,
+  fetchChannelError: null,
   readStatus: null,
   messageListParams: null,
   typingMembers: [],

--- a/src/modules/Channel/context/dux/reducers.ts
+++ b/src/modules/Channel/context/dux/reducers.ts
@@ -47,6 +47,7 @@ export default function channelReducer(
         hasMoreNext: false,
         allMessages: [],
         localMessages: [],
+        fetchChannelError: null,
       };
     })
     .with({ type: channelActions.FETCH_INITIAL_MESSAGES_START }, () => {
@@ -58,6 +59,7 @@ export default function channelReducer(
           : true,
         ),
         localMessages: [],
+        fetchChannelError: null,
       };
     })
     .with({ type: channelActions.FETCH_INITIAL_MESSAGES_SUCCESS }, (action) => {
@@ -75,6 +77,7 @@ export default function channelReducer(
         hasMoreNext: true,
         oldestMessageTimeStamp,
         latestMessageTimeStamp,
+        fetchChannelError: null,
         allMessages: [...messages],
       };
     })
@@ -100,12 +103,10 @@ export default function channelReducer(
           ? duplicatedMessage
           : msg;
       });
-      const filteredNewMessages = duplicatedMessageIds.length > 0
-        ? messages.filter(
-          (msg) => !duplicatedMessageIds.find((messageId) => compareIds(messageId, msg.messageId),
-          ),
-        )
-        : messages;
+      const filteredNewMessages =
+        duplicatedMessageIds.length > 0
+          ? messages.filter((msg) => !duplicatedMessageIds.find((messageId) => compareIds(messageId, msg.messageId)))
+          : messages;
 
       return {
         ...state,
@@ -151,6 +152,7 @@ export default function channelReducer(
           ...state,
           loading: false,
           isInvalid: shouldInvalid,
+          fetchChannelError: action.type === channelActions.FETCH_INITIAL_MESSAGES_FAILURE && action.payload.fetchChannelError,
           initialized: false,
           allMessages: [],
           hasMorePrev: false,

--- a/src/modules/Channel/context/hooks/useHandleReconnect.ts
+++ b/src/modules/Channel/context/hooks/useHandleReconnect.ts
@@ -96,7 +96,7 @@ function useHandleReconnect(
                 logger.error('Channel: Fetching messages failed', error);
                 messagesDispatcher({
                   type: messageActionTypes.FETCH_INITIAL_MESSAGES_FAILURE,
-                  payload: { currentGroupChannel },
+                  payload: { currentGroupChannel, fetchChannelError: error },
                 });
               });
             if (!disableMarkAsRead) {

--- a/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
+++ b/src/modules/Channel/context/hooks/useInitialMessagesFetch.ts
@@ -109,7 +109,7 @@ function useInitialMessagesFetch(
           logger.error('Channel: Fetching messages failed', error);
           messagesDispatcher({
             type: messageActionTypes.FETCH_INITIAL_MESSAGES_FAILURE,
-            payload: { currentGroupChannel },
+            payload: { currentGroupChannel, fetchChannelError: error },
           });
         })
         .finally(() => {


### PR DESCRIPTION
## Description

Expose the fetch error when getting channel messages.

This matches what they do in GroupChannel (Which we can't use yet)

## Test Plan

1. Download Charles Proxy
2. Click "Tools" -> "Block List" -> "Add" -> Enter the information below.
 **protocol**: https
**url**: api-7935a0c6-72df-40d5-85e7-e50610c795a8.sendbird.com
**path**: v3/group_channels/your-channel-url/messages
**port**: 443
3. Open Chat
4. Observe Error Screen
5. Unblock request in Charles
6. Click "retry" to observe chat reloading correctly.
7. Observe that the fetchChannelError contains the network failure error.
