### PR TITLE
[APP-6458] - support pass through edit input

### DIFF
--- a/src/modules/Channel/components/ChannelUI/index.tsx
+++ b/src/modules/Channel/components/ChannelUI/index.tsx
@@ -13,6 +13,8 @@ export interface ChannelUIProps extends GroupChannelUIBasicProps {
    * Customizes all child components of the message component.
    * */
   renderMessage?: GroupChannelUIBasicProps['renderMessage'];
+
+  renderEditInput?: GroupChannelUIBasicProps['renderEditInput'];
 }
 
 const ChannelUI = (props: ChannelUIProps) => {

--- a/src/modules/Channel/components/MessageList/index.tsx
+++ b/src/modules/Channel/components/MessageList/index.tsx
@@ -32,6 +32,8 @@ export interface MessageListProps extends GroupChannelMessageListProps {
    * Customizes all child components of the message component.
    * */
   renderMessage?: GroupChannelUIBasicProps['renderMessage'];
+
+  renderEditInput?: GroupChannelUIBasicProps['renderEditInput'];
 }
 export const MessageList = ({
   className = '',
@@ -43,6 +45,7 @@ export const MessageList = ({
   renderPlaceholderEmpty = () => <PlaceHolder className="sendbird-conversation__no-messages" type={PlaceHolderTypes.NO_MESSAGES} />,
   renderFrozenNotification = () => <FrozenNotification className="sendbird-conversation__messages__notification" />,
   renderRemoveMessageModal,
+  renderEditInput
 }: MessageListProps) => {
   const {
     allMessages,
@@ -208,6 +211,7 @@ export const MessageList = ({
                     renderSuggestedReplies={renderSuggestedReplies}
                     renderCustomSeparator={renderCustomSeparator}
                     renderRemoveMessageModal={renderRemoveMessageModal}
+                    renderEditInput={renderEditInput}
                     // backward compatibility
                     renderMessage={renderMessage}
                   />
@@ -234,6 +238,7 @@ export const MessageList = ({
                     renderMessageContent={renderMessageContent}
                     renderSuggestedReplies={renderSuggestedReplies}
                     renderCustomSeparator={renderCustomSeparator}
+                    renderEditInput={renderEditInput}
                     // backward compatibility
                     renderMessage={renderMessage}
                   />

--- a/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
+++ b/src/modules/GroupChannel/components/GroupChannelUI/GroupChannelUIView.tsx
@@ -8,7 +8,7 @@ import { TypingIndicatorType } from '../../../../types';
 import ConnectionStatus from '../../../../ui/ConnectionStatus';
 import PlaceHolder, { PlaceHolderTypes } from '../../../../ui/PlaceHolder';
 
-import type { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../../types';
+import type { ClientUserMessage, EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType } from '../../../../types';
 import type { GroupChannelHeaderProps } from '../GroupChannelHeader';
 import type { GroupChannelMessageListProps } from '../MessageList';
 import type { MessageContentProps } from '../../../../ui/MessageContent';
@@ -83,6 +83,8 @@ export interface GroupChannelUIBasicProps {
   renderTypingIndicator?: () => React.ReactElement;
 
   renderRemoveMessageModal?: (props: { message: EveryMessage; onCancel: () => void; onSubmit: () => void }) => React.ReactElement;
+
+  renderEditInput?: ({ onCancelEdit, message }: { onCancelEdit: VoidFunction; message: ClientUserMessage }) => React.ReactElement;
 }
 
 export interface GroupChannelUIViewProps extends GroupChannelUIBasicProps {

--- a/src/modules/GroupChannel/components/Message/MessageView.tsx
+++ b/src/modules/GroupChannel/components/Message/MessageView.tsx
@@ -1,4 +1,4 @@
-import type { EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType, ReplyType } from '../../../../types';
+import type { ClientUserMessage, EveryMessage, RenderCustomSeparatorProps, RenderMessageParamsType, ReplyType } from '../../../../types';
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { EmojiContainer, User } from '@sendbird/chat';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
@@ -47,7 +47,7 @@ export interface MessageProps {
   /**
    * A function that customizes the rendering of the edit input portion of the message component.
    * */
-  renderEditInput?: () => React.ReactElement;
+  renderEditInput?: ({ onCancelEdit, message }: { onCancelEdit: VoidFunction; message: ClientUserMessage }) => React.ReactElement;
   /**
    * @deprecated Please use `children` instead
    * @description Customizes all child components of the message.
@@ -165,6 +165,15 @@ const MessageView = (props: MessageViewProps) => {
   const mentionNodes = useDirtyGetMentions({ ref: editMessageInputRef }, { logger });
   const ableMention = mentionNodes?.length < maxUserMentionCount;
 
+  const handleCancelEdit = () => {
+    setMentionNickname('');
+    setMentionedUsers([]);
+    setMentionedUserIds([]);
+    setMentionSuggestedUsers([]);
+    setShowEdit(false);
+    channel?.endTyping?.();
+  };
+
   useEffect(() => {
     setMentionedUsers(
       mentionedUsers.filter(({ userId }) => {
@@ -276,7 +285,7 @@ const MessageView = (props: MessageViewProps) => {
 
   if (showEdit && message?.isUserMessage?.()) {
     return (
-      renderEditInput?.() || (
+      renderEditInput?.({ onCancelEdit: handleCancelEdit, message }) || (
         <>
           {displaySuggestedMentionList && (
             <SuggestedMentionListView
@@ -323,14 +332,7 @@ const MessageView = (props: MessageViewProps) => {
               setShowEdit(false);
               channel?.endTyping?.();
             }}
-            onCancelEdit={() => {
-              setMentionNickname('');
-              setMentionedUsers([]);
-              setMentionedUserIds([]);
-              setMentionSuggestedUsers([]);
-              setShowEdit(false);
-              channel?.endTyping?.();
-            }}
+            onCancelEdit={handleCancelEdit}
             onUserMentioned={(user) => {
               if (selectedUser?.userId === user?.userId) {
                 setSelectedUser(null);


### PR DESCRIPTION
## Description
The library has a renderEditInput function that isn't really being utilized effectively. I update the fork so that you can pass the functional component all the way from the ChannelUI component and gives it the UI tools it needs, onCancel and the message itself. onSubmit is available via the sdk.

## Test Plan
The code changes extend the api but there's nothing to test
