### PR TITLE
Fix channel fetch error when user leaves a nook channel

### DIFF
--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -135,7 +135,7 @@ export default function channelListReducer(
         const { channel, isMe } = action.payload;
         const { allChannels, currentUserId, currentChannel, channelListQuery, disableAutoSelect } = state;
         let nextChannels = [...allChannels];
-        let nextChannel: GroupChannel = channel;
+        let nextChannel: GroupChannel = currentChannel;
 
         /**
          * 1. If I left channel:
@@ -156,6 +156,9 @@ export default function channelListReducer(
           const channelAt = allChannels.findIndex((ch: GroupChannel) => ch.url === channel.url);
           if (channelAt > -1) {
             nextChannels.splice(channelAt, 1);
+          }
+
+          if (currentChannel) {
             nextChannel = getNextChannel({
               channel,
               currentChannel,


### PR DESCRIPTION
## Description
UIKit throws a 400 every time the user leaves a nook channel.
![Screenshot 2024-03-20 at 10 54 37 AM](https://github.com/sendbird/sendbird-uikit-react/assets/51099886/4cc02876-f24b-468b-9464-1d03c6d26682)

This is bc we set activeChannel to null and UIKit doesn't handle that nicely -> then `getNextChannel` is called and the channel we just left is returned -> channel we just left is set to the active channel -> SB tries to fetch that channel

## Test Plan
- be in a nook channel
- leave the channel
- no more error

all other active channel stuff works as expected. tested other user leaving nook channel -> nothing happens