### PR TITLE
[APP-6559] - allow enabling reaction tooltips for super group channels

### DIFF
--- a/src/ui/EmojiReactions/ReactionItem.tsx
+++ b/src/ui/EmojiReactions/ReactionItem.tsx
@@ -27,6 +27,7 @@ type Props = {
   emojisMap: Map<string, Emoji>;
   channel: Nullable<GroupChannel | OpenChannel>;
   message?: SendableMessageType;
+  showReactionsForSuperGroups?: boolean;
 };
 
 export default function ReactionItem({
@@ -37,6 +38,7 @@ export default function ReactionItem({
   emojisMap,
   channel,
   message,
+  showReactionsForSuperGroups
 }: Props) {
   const store = useSendbirdStateContext();
   const { isMobile } = useMediaQueryContext();
@@ -46,7 +48,7 @@ export default function ReactionItem({
   const userId = store.config.userId;
   const reactedByMe = isReactedBy(userId, reaction);
   const showHoverTooltip = (reaction.userIds.length > 0)
-    && (channel?.isGroupChannel() && !channel.isSuper);
+    && (channel?.isGroupChannel() && (!channel.isSuper || showReactionsForSuperGroups));
 
   const handleOnClick = () => {
     setEmojiKey('');

--- a/src/ui/EmojiReactions/index.tsx
+++ b/src/ui/EmojiReactions/index.tsx
@@ -30,6 +30,7 @@ export interface EmojiReactionsProps {
   isByMe?: boolean;
   toggleReaction?: (message: SendableMessageType, key: string, byMe: boolean) => void;
   onPressUserProfile?: (member: User) => void;
+  showReactionsForSuperGroups?: boolean;
 }
 
 const EmojiReactions = ({
@@ -43,6 +44,7 @@ const EmojiReactions = ({
   isByMe = false,
   toggleReaction,
   onPressUserProfile,
+  showReactionsForSuperGroups = false
 }: EmojiReactionsProps): ReactElement => {
   const { isMobile } = useMediaQueryContext();
   const addReactionRef = useRef(null);
@@ -69,6 +71,7 @@ const EmojiReactions = ({
               emojisMap={emojisMap}
               channel={channel}
               message={message}
+              showReactionsForSuperGroups={showReactionsForSuperGroups}
             />
           );
         })


### PR DESCRIPTION
## Description
Allow overriding default behavior that is preventing tooltips from displaying for super groups.

## Test Plan
With an `EmojiReaction` component with `showReactionsForSuperGroups` set to true, verify that the emoji reaction tooltip is displayed on hover.
