### PR TITLE
[APP-6637] - fix message list not pinning to bottom

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -148,13 +148,13 @@ export const MessageList = ({
       );
     },
   };
-
-  const isMessageListRendered = !loading && messages.length > 0;
+  const isMessageListEmpty = messages.length === 0;
+  const isMessageListRendered = !loading && !isMessageListEmpty;
 
   const renderMessageBody = () => {
     if (loading) {
       return renderPlaceholderLoader();
-    } else if (messages.length === 0) {
+    } else if (isMessageListEmpty) {
       return renderPlaceholderEmpty();
     }
     return (

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -196,6 +196,8 @@ export const MessageList = ({
   }
 
   const renderMessageListAuxillaryComponents = () => {
+    const shouldDisplayScrollToBottom = hasNext() || !isScrollBottomReached;
+    const shouldDisplayUnreadNotifications = !!(!isScrollBottomReached && unreadSinceDate);
     return (
       <>
         <>{renderer.frozenNotification()}</>
@@ -205,8 +207,8 @@ export const MessageList = ({
             onScrollToUnread: scrollToBottom,
             unreadCount: newMessages.length,
             lastReadAt: unreadSinceDate,
-            shouldDisplayScrollToBottom: hasNext() || !isScrollBottomReached,
-            shouldDisplayUnreadNotifications: Boolean(!isScrollBottomReached && unreadSinceDate),
+            shouldDisplayScrollToBottom,
+            shouldDisplayUnreadNotifications,
           }) : (
             <>
               <>{renderer.unreadMessagesNotification()}</>

--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -149,55 +149,55 @@ export const MessageList = ({
     },
   };
 
-  if (loading) {
-    return renderPlaceholderLoader();
+  const isMessageListRendered = !loading && messages.length > 0;
+
+  const renderMessageBody = () => {
+    if (loading) {
+      return renderPlaceholderLoader();
+    } else if (messages.length === 0) {
+      return renderPlaceholderEmpty();
+    }
+    return (
+      <>
+        {messages.map((message, idx) => {
+          const { chainTop, chainBottom, hasSeparator } = getMessagePartsInfo({
+            allMessages: messages as CoreMessageType[],
+            replyType,
+            isMessageGroupingEnabled,
+            currentIndex: idx,
+            currentMessage: message as CoreMessageType,
+            currentChannel,
+          });
+          const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
+          return (
+            <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
+              {renderMessage({
+                handleScroll: onMessageContentSizeChanged,
+                message: message as EveryMessage,
+                hasSeparator,
+                chainTop,
+                chainBottom,
+                renderMessageContent,
+                renderSuggestedReplies,
+                renderCustomSeparator,
+                renderRemoveMessageModal,
+                renderEditInput
+              })}
+            </MessageProvider>
+          );
+        })}
+        {!hasNext() &&
+          store?.config?.groupChannel?.enableTypingIndicator &&
+          store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
+          <TypingIndicatorBubbleWrapper channelUrl={channelUrl} handleScroll={onMessageContentSizeChanged} />
+        )} 
+      </> 
+    )
   }
 
-  if (messages.length === 0) {
-    return renderPlaceholderEmpty();
-  }
-
-  return (
-    <>
-      <div className={`sendbird-conversation__messages ${className}`}>
-        <div className="sendbird-conversation__scroll-container">
-          <div className="sendbird-conversation__padding" />
-          <div className="sendbird-conversation__messages-padding" ref={scrollRef}>
-            {messages.map((message, idx) => {
-              const { chainTop, chainBottom, hasSeparator } = getMessagePartsInfo({
-                allMessages: messages as CoreMessageType[],
-                replyType,
-                isMessageGroupingEnabled,
-                currentIndex: idx,
-                currentMessage: message as CoreMessageType,
-                currentChannel,
-              });
-              const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
-              return (
-                <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
-                  {renderMessage({
-                    handleScroll: onMessageContentSizeChanged,
-                    message: message as EveryMessage,
-                    hasSeparator,
-                    chainTop,
-                    chainBottom,
-                    renderMessageContent,
-                    renderSuggestedReplies,
-                    renderCustomSeparator,
-                    renderRemoveMessageModal,
-                    renderEditInput
-                  })}
-                </MessageProvider>
-              );
-            })}
-            {!hasNext() &&
-              store?.config?.groupChannel?.enableTypingIndicator &&
-              store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
-                <TypingIndicatorBubbleWrapper channelUrl={channelUrl} handleScroll={onMessageContentSizeChanged} />
-              )}
-          </div>
-        </div>
-
+  const renderMessageListAuxillaryComponents = () => {
+    return (
+      <>
         <>{renderer.frozenNotification()}</>
         {
           renderScrollToBottomOrUnread ? renderScrollToBottomOrUnread({
@@ -206,7 +206,7 @@ export const MessageList = ({
             unreadCount: newMessages.length,
             lastReadAt: unreadSinceDate,
             shouldDisplayScrollToBottom: hasNext() || !isScrollBottomReached,
-            shouldDisplayUnreadNotifications: !!(!isScrollBottomReached && unreadSinceDate),
+            shouldDisplayUnreadNotifications: Boolean(!isScrollBottomReached && unreadSinceDate),
           }) : (
             <>
               <>{renderer.unreadMessagesNotification()}</>
@@ -214,6 +214,22 @@ export const MessageList = ({
             </>
           )
         }
+      </>
+    )
+    
+  }
+
+  return (
+    <>
+      <div className={`sendbird-conversation__messages ${className}`}>
+        <div className="sendbird-conversation__scroll-container">
+          <div className="sendbird-conversation__padding" />
+          <div className="sendbird-conversation__messages-padding" ref={scrollRef}>
+            {renderMessageBody()}
+          </div>
+        </div>
+
+        {isMessageListRendered && renderMessageListAuxillaryComponents()}
       </div>
     </>
   );


### PR DESCRIPTION
## Description
The scrollToBottom is controlled by a pubsub system.
For a brand new channel, currently the scrollToBottom pubsub event is not subscribed to in the GroupChannelProvider because of a coroutine lock. This causes the scrollToBottom functionality to not trigger for new channels (specifically channels that are entered with 0 messages).

The coroutine locks indefinitely because when the message count is 0, the message list renders empty states and the scrollRef on the list is not bound when expected.

The fix is to render the empty and loader states within the scrollRef bound container div.

## Test Plan
