### PR TITLE
APP-6709 increase chat scroll to bottom button render threshold and

### DIFF
--- a/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
+++ b/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
@@ -1,8 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import pubSubFactory from '../../../../lib/pubSub';
 import { useOnScrollPositionChangeDetectorWithRef } from '../../../../hooks/useOnScrollReachedEndDetector';
-import { SCROLL_BUFFER } from '../../../../utils/consts';
-import { isAboutSame } from '../../../../utils/utils';
 
 /**
  * You can pass the resolve function to scrollPubSub, if you want to catch when the scroll is finished.
@@ -87,7 +85,11 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto') {
 
           // Update data by manual update
           scrollDistanceFromBottomRef.current = Math.max(0, scrollHeight - scrollTop - clientHeight);
-          setIsScrollBottomReached(isAboutSame(scrollDistanceFromBottomRef.current, 0, SCROLL_BUFFER));
+
+          // This is commented out because we don't want the bottom reached 
+          // computation to trigger on content size change. useOnScrollPositionChangeDetectorWithRef will
+          // trigger the computation on true scrolling.
+          // setIsScrollBottomReached(scrollDistanceFromBottomRef.current === 0);
 
           if (resolve) resolve();
         }, lazy);

--- a/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
+++ b/src/modules/GroupChannel/context/hooks/useMessageListScroll.ts
@@ -1,6 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import pubSubFactory from '../../../../lib/pubSub';
 import { useOnScrollPositionChangeDetectorWithRef } from '../../../../hooks/useOnScrollReachedEndDetector';
+import { SCROLL_BUFFER } from '../../../../utils/consts';
+import { isAboutSame } from '../../../../utils/utils';
 
 /**
  * You can pass the resolve function to scrollPubSub, if you want to catch when the scroll is finished.
@@ -85,7 +87,7 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto') {
 
           // Update data by manual update
           scrollDistanceFromBottomRef.current = Math.max(0, scrollHeight - scrollTop - clientHeight);
-          setIsScrollBottomReached(scrollDistanceFromBottomRef.current === 0);
+          setIsScrollBottomReached(isAboutSame(scrollDistanceFromBottomRef.current, 0, SCROLL_BUFFER));
 
           if (resolve) resolve();
         }, lazy);

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,5 +1,5 @@
 export const ONE_MiB = 1024 * 1024;
-export const SCROLL_BUFFER = 40;
+export const SCROLL_BUFFER = 30;
 export const SCROLL_BOTTOM_DELAY_FOR_SEND = 100;
 export const SCROLL_BOTTOM_DELAY_FOR_FETCH = 100;
 

--- a/src/utils/consts.ts
+++ b/src/utils/consts.ts
@@ -1,5 +1,5 @@
 export const ONE_MiB = 1024 * 1024;
-export const SCROLL_BUFFER = 10;
+export const SCROLL_BUFFER = 40;
 export const SCROLL_BOTTOM_DELAY_FOR_SEND = 100;
 export const SCROLL_BOTTOM_DELAY_FOR_FETCH = 100;
 


### PR DESCRIPTION
## Description
1. Bumping the threshold from 10 to 30. This affects when the scroll to bottom button is rendered when you scroll over 30 px from the bottom.
2. Remove the bottom reached calculation from triggering due to content size change. This fixes the scroll to bottom button from rendering briefly when reacting to a message. Another way to fix this would've been to up the scroll buffer to 40px, and  converting 
```
          setIsScrollBottomReached(scrollDistanceFromBottomRef.current === 0);
```
to 

```
          setIsScrollBottomReached(isAboutSame(scrollDistanceFromBottomRef.current, 0, SCROLL_BUFFER));

```
but that's a bit inflexible.

## Test Plan

