### PR TITLE
[APP-6675] - fix flicker when entering channel and paginating

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -1,5 +1,5 @@
 import './index.scss';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { Member } from '@sendbird/chat/groupChannel';
 import { useGroupChannelHandler } from '@sendbird/uikit-tools';
 
@@ -19,6 +19,7 @@ import TypingIndicatorBubble from '../../../../ui/TypingIndicatorBubble';
 import { useGroupChannelContext } from '../../context/GroupChannelProvider';
 import { getComponentKeyFromMessage } from '../../context/utils';
 import { GroupChannelUIBasicProps } from '../GroupChannelUI/GroupChannelUIView';
+import { BaseMessage } from '@sendbird/chat/message';
 
 export interface GroupChannelMessageListProps {
   className?: string;
@@ -56,6 +57,37 @@ export interface GroupChannelMessageListProps {
   renderEditInput?: GroupChannelUIBasicProps['renderEditInput'];
 
   renderScrollToBottomOrUnread?: GroupChannelUIBasicProps['renderScrollToBottomOrUnread'];
+}
+
+const MessageListContainer = ({ scrollRef, renderList, messages }: { 
+  scrollRef: React.MutableRefObject<HTMLDivElement>, 
+  renderList: () => React.ReactElement,
+  messages: BaseMessage[]
+}) => {
+  const prevMessagesLengthRef = useRef(messages.length);
+
+  // handles scrolling the list to the bottom before browser paint
+  useLayoutEffect(() => {
+    if (!scrollRef.current) return;
+
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, []);
+
+  // If message count has increased and you were scrolled to the top
+  // scroll down 1px so the scrollbar isn't anchored to the top when the new items get rendered.
+  // This fixes a flicker that happens when old messages get rendered in.
+  useLayoutEffect(() => {
+    if (messages.length > prevMessagesLengthRef.current && scrollRef.current.scrollTop === 0) {
+      scrollRef.current.scrollTop = 1;
+    }
+    prevMessagesLengthRef.current = messages.length;
+  }, [messages])
+
+  return (
+    <div className="sendbird-conversation__messages-padding" ref={scrollRef}>
+      {renderList()}
+    </div>
+  )
 }
 
 export const MessageList = ({
@@ -148,77 +180,13 @@ export const MessageList = ({
       );
     },
   };
-  const isMessageListEmpty = messages.length === 0;
-  const isMessageListRendered = !loading && !isMessageListEmpty;
 
-  const renderMessageBody = () => {
-    if (loading) {
-      return renderPlaceholderLoader();
-    } else if (isMessageListEmpty) {
-      return renderPlaceholderEmpty();
-    }
-    return (
-      <>
-        {messages.map((message, idx) => {
-          const { chainTop, chainBottom, hasSeparator } = getMessagePartsInfo({
-            allMessages: messages as CoreMessageType[],
-            replyType,
-            isMessageGroupingEnabled,
-            currentIndex: idx,
-            currentMessage: message as CoreMessageType,
-            currentChannel,
-          });
-          const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
-          return (
-            <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
-              {renderMessage({
-                handleScroll: onMessageContentSizeChanged,
-                message: message as EveryMessage,
-                hasSeparator,
-                chainTop,
-                chainBottom,
-                renderMessageContent,
-                renderSuggestedReplies,
-                renderCustomSeparator,
-                renderRemoveMessageModal,
-                renderEditInput
-              })}
-            </MessageProvider>
-          );
-        })}
-        {!hasNext() &&
-          store?.config?.groupChannel?.enableTypingIndicator &&
-          store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
-          <TypingIndicatorBubbleWrapper channelUrl={channelUrl} handleScroll={onMessageContentSizeChanged} />
-        )} 
-      </> 
-    )
+  if (loading) {
+    return renderPlaceholderLoader();
   }
 
-  const renderMessageListAuxillaryComponents = () => {
-    const shouldDisplayScrollToBottom = hasNext() || !isScrollBottomReached;
-    const shouldDisplayUnreadNotifications = !!(!isScrollBottomReached && unreadSinceDate);
-    return (
-      <>
-        <>{renderer.frozenNotification()}</>
-        {
-          renderScrollToBottomOrUnread ? renderScrollToBottomOrUnread({
-            onScrollToBottom: scrollToBottom,
-            onScrollToUnread: scrollToBottom,
-            unreadCount: newMessages.length,
-            lastReadAt: unreadSinceDate,
-            shouldDisplayScrollToBottom,
-            shouldDisplayUnreadNotifications,
-          }) : (
-            <>
-              <>{renderer.unreadMessagesNotification()}</>
-              <>{renderer.scrollToBottomButton()}</>
-            </>
-          )
-        }
-      </>
-    )
-    
+  if (messages.length === 0) {
+    return renderPlaceholderEmpty();
   }
 
   return (
@@ -226,12 +194,64 @@ export const MessageList = ({
       <div className={`sendbird-conversation__messages ${className}`}>
         <div className="sendbird-conversation__scroll-container">
           <div className="sendbird-conversation__padding" />
-          <div className="sendbird-conversation__messages-padding" ref={scrollRef}>
-            {renderMessageBody()}
-          </div>
+            <MessageListContainer
+              scrollRef={scrollRef}
+              messages={messages}
+              renderList={() => (
+                <>
+                  {messages.map((message, idx) => {
+                    const { chainTop, chainBottom, hasSeparator } = getMessagePartsInfo({
+                      allMessages: messages as CoreMessageType[],
+                      replyType,
+                      isMessageGroupingEnabled,
+                      currentIndex: idx,
+                      currentMessage: message as CoreMessageType,
+                      currentChannel,
+                    });
+                    const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
+                    return (
+                      <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
+                        {renderMessage({
+                          handleScroll: onMessageContentSizeChanged,
+                          message: message as EveryMessage,
+                          hasSeparator,
+                          chainTop,
+                          chainBottom,
+                          renderMessageContent,
+                          renderSuggestedReplies,
+                          renderCustomSeparator,
+                          renderRemoveMessageModal,
+                          renderEditInput
+                        })}
+                      </MessageProvider>
+                    );
+                  })}
+                  {!hasNext() &&
+                    store?.config?.groupChannel?.enableTypingIndicator &&
+                    store?.config?.groupChannel?.typingIndicatorTypes?.has(TypingIndicatorType.Bubble) && (
+                      <TypingIndicatorBubbleWrapper channelUrl={channelUrl} handleScroll={onMessageContentSizeChanged} />
+                  )}
+                </>
+              )}
+            />
         </div>
 
-        {isMessageListRendered && renderMessageListAuxillaryComponents()}
+        <>{renderer.frozenNotification()}</>
+        {
+          renderScrollToBottomOrUnread ? renderScrollToBottomOrUnread({
+            onScrollToBottom: scrollToBottom,
+            onScrollToUnread: scrollToBottom,
+            unreadCount: newMessages.length,
+            lastReadAt: unreadSinceDate,
+            shouldDisplayScrollToBottom: hasNext() || !isScrollBottomReached,
+            shouldDisplayUnreadNotifications: !!(!isScrollBottomReached && unreadSinceDate),
+          }) : (
+            <>
+              <>{renderer.unreadMessagesNotification()}</>
+              <>{renderer.scrollToBottomButton()}</>
+            </>
+          )
+        }
       </div>
     </>
   );


### PR DESCRIPTION
## Description
Sendbird renders lists and scrolls them to the bottom on render through a pubsub system. The problem is this happens after first paint, so there is a flicker.

To get around this flicker, we can scroll to bottom before the first render.

To fix this I reverted a different fix I had, which would render the empty and loader states in the ref bound `div`. This was necessary so that the ref scrollHeight would be determined by messages alone, instead of by empty and loading states. That way, `ref.scrollTop = ref.scrollHeight` actually scrolls the list to the bottom before first paint in the useLayoutEffect.


Some other things I do in this PR:
1. set the isScrollBottomReached flag to bottom on mount. This prevents the bottom scroll button from flickering on mount. We want to start the list scrolled to the bottom, so this only natural I think for the flag to start as `true`.
2. I apply a potential fix to smoothen scroll that happens when reaching the pagination threshold for old messages.
3. I re-fix the old problem with a different approach after reverting (described above). 

## Test Plan

