### PR TITLE
[APP-6730] - smooth over message list pagination

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -78,10 +78,27 @@ const MessageListContainer = ({ scrollRef, renderList, messages }: {
   // This fixes a flicker that happens when old messages get rendered in.
   useLayoutEffect(() => {
     if (messages.length > prevMessagesLengthRef.current && scrollRef.current.scrollTop === 0) {
+      scrollRef.current.style.overflowY = 'hidden';
       scrollRef.current.scrollTop = 1;
     }
     prevMessagesLengthRef.current = messages.length;
-  }, [messages])
+  }, [messages]);
+
+  useLayoutEffect(() => {
+    // The above useLayoutEffect is not sufficient because of scroll inertia and bounce.
+    // To deal with inertia and bounce, the list is temporarily rendered a non-scrollable list.
+    // This cancels the inertia and, as a result, bounce.
+    const cb = () => {
+      if (scrollRef.current.scrollTop === 0) {
+        scrollRef.current.scrollTop = 1;
+        scrollRef.current.style.overflowY = 'hidden';
+      } else {
+        scrollRef.current.style.overflowY = 'scroll';
+      }
+    };
+    scrollRef.current.addEventListener('scroll', cb)
+    return () => scrollRef.current.removeEventListener('scroll', cb)
+  }, [])
 
   return (
     <div className="sendbird-conversation__messages-padding" ref={scrollRef}>


### PR DESCRIPTION
## Description
Choppy pagination. I had implemented a fix for this in a previous PR but I don't think it works well alone because of scrolling inertia.

https://github.com/gathertown/sendbird-uikit-react/assets/18584664/5e133116-a6c5-49b1-a304-21bbaaaaaa1a


## Test Plan


https://github.com/gathertown/sendbird-uikit-react/assets/18584664/e3a8cb6f-6210-4a52-924a-e0ac9cda8c45



