### PR TITLE
[APP-6742] - remove read status from grouping logic

### DIFF
--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -75,8 +75,6 @@ export const isSameGroup = (
     message?.sendingStatus === comparingMessage?.sendingStatus
     && message?.sender?.userId === comparingMessage?.sender?.userId
     && getMessageCreatedAt(message) === getMessageCreatedAt(comparingMessage)
-  ) && (
-    currentChannel ? isReadMessage(currentChannel, message) === isReadMessage(currentChannel, comparingMessage) : true
   );
 };
 


### PR DESCRIPTION
## Description
I'm removing read status in how message groups are calculated. A category of scrolling issues have to do with how timestamps are rendered. If a timestamp is rendered and then unrendered (not stable), then it can cause a scroll bug.


I believe that read status is causing groups with the same timestamp to split.
Workflow

User A sends User B messages 1 to 5.
User B reads messages 1 to 5.

User A sends User B messages 6 to 10.
User B doesn't read yet, they are backgrounded
User A sees a split in groups

## Test Plan

User A sends User B messages 1 to 5.
User B reads messages 1 to 5.

User A sends User B messages 6 to 10.
User B doesn't read yet, they are backgrounded
User A does not see a split in the group
