### PR TITLE
[APP-6751] - fix date header scroll behavior bug

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/getMessagePartsInfo.ts
+++ b/src/modules/GroupChannel/components/MessageList/getMessagePartsInfo.ts
@@ -40,10 +40,10 @@ export const getMessagePartsInfo = ({
   const currentCreatedAt = currentMessage.createdAt;
 
   // NOTE: for pending/failed messages
-  const isLocalMessage = 'sendingStatus' in currentMessage && (currentMessage.sendingStatus !== 'succeeded');
+  // const isLocalMessage = 'sendingStatus' in currentMessage && (currentMessage.sendingStatus !== 'succeeded');
 
   // https://stackoverflow.com/a/41855608
-  const hasSeparator = isLocalMessage ? false : !(previousMessageCreatedAt && (isSameDay(currentCreatedAt, previousMessageCreatedAt)));
+  const hasSeparator = !(previousMessageCreatedAt && (isSameDay(currentCreatedAt, previousMessageCreatedAt)));
   return {
     chainTop,
     chainBottom,


### PR DESCRIPTION
## Description

https://github.com/gathertown/sendbird-uikit-react/assets/18584664/df398d46-0c41-4905-b884-28c1b60e0767

There are two ways to fix this,
1. (The chosen approach), rendering the date header even if the message is pending. This fixes the problem because the initially rendered height is the final height
2. The more adaptive approach is to listen on change in sending status and recalc the scroll based on it. This doesn't work out of the box, we have to stabilize the message component key (use message.reqId instead of message.messageId since messageId is 0 for pending messages). And then we have to add an effect to the message component that triggers onMessageContentHeightChange hook when sending status changes. I did not go with this approach because even though it is adaptive, it causes some flicker as the content changes height

## Test Plan


https://github.com/gathertown/sendbird-uikit-react/assets/18584664/0bb84a9e-3c73-4128-8d6a-db4268195361


