### PR TITLE
[APP-6981] - fix persisting scroll to bottom button

### DIFF
--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -56,10 +56,12 @@ export function useOnScrollPositionChangeDetectorWithRef(
             distanceFromBottom: scrollHeight - scrollTop - clientHeight,
           };
 
-          if (_params.current.onReachedTop && isAboutSame(scrollTop, 0, SCROLL_BUFFER)) {
-            _params.current.onReachedTop(event);
-          } else if (_params.current.onReachedBottom && isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER)) {
+          const reachedTop = _params.current.onReachedTop && isAboutSame(scrollTop, 0, SCROLL_BUFFER);
+          const reachedBottom = _params.current.onReachedBottom && isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER);
+          if (reachedBottom) {
             _params.current.onReachedBottom(event);
+          } else if (reachedTop) {
+            _params.current.onReachedTop(event);
           } else if (_params.current.onInBetween) {
             _params.current.onInBetween(event);
           }


### PR DESCRIPTION
## Description
If the user's message list meets both "scrolled to top" and "scrolled to bottom" criteria, its going to prioritize "scrolled to top", which is a problem because then we can't get rid of the scroll to bottom button.

## Test Plan
Insert just enough content to reach the size of the message list container height.
Verify that the scroll to bottom button is not present.

<img width="200" alt="Screenshot 2024-04-23 at 9 46 59 AM" src="https://github.com/gathertown/sendbird-uikit-react/assets/18584664/7245e3df-d2c8-467e-b460-bfc2dc9c40ae">
