### PR TITLE
Remove forced casting and correctly type SDK

### DIFF
--- a/src/lib/dux/sdk/initialState.ts
+++ b/src/lib/dux/sdk/initialState.ts
@@ -3,14 +3,14 @@ import { SdkStore } from '../../types';
 export interface SdkStoreStateType {
   initialized: SdkStore['initialized']
   loading: SdkStore['loading']
-  sdk: SdkStore['sdk'],
+  sdk: SdkStore['sdk'] | null,
   error: SdkStore['error'];
 }
 
 const initialState: SdkStoreStateType = {
   initialized: false,
   loading: false,
-  sdk: {} as SdkStore['sdk'],
+  sdk: null,
   error: false,
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -127,7 +127,7 @@ export interface SdkStore {
   error: boolean;
   initialized: boolean;
   loading: boolean;
-  sdk: SendbirdChatType;
+  sdk: SendbirdChatType | null;
 }
 
 export interface UserStore {


### PR DESCRIPTION
## Description

UIKIt was previously casting an empty object to be SendbirdChatType. This caused a SEV. This PR removes this forced casting and correctly types it as being nullable.

## Test Plan

- Ensure no build errors
- Run in Gather and confirm no runtime errors occur
