### PR TITLE
Ensure the SDK isn't undefined before called disconnect

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -242,7 +242,7 @@ const SendbirdSDK = ({
   });
 
   useUnmount(() => {
-    if (typeof sdk.disconnect === 'function') {
+    if (typeof sdk?.disconnect === 'function') {
       disconnectSdk({
         logger,
         sdkDispatcher,
@@ -250,7 +250,7 @@ const SendbirdSDK = ({
         sdk,
       });
     }
-  }, [sdk.disconnect]);
+  }, [sdk?.disconnect]);
 
   // to create a pubsub to communicate between parent and child
   useEffect(() => {


### PR DESCRIPTION
## Description

It turns out the disconnect code on unmount expects the SDK to always be defined. This PR checks SDK is defined before calling disconnect.

## Test Plan

- [x] Ensure no build errors
- [x] Run in Gather and confirm no runtime errors occur
