### PR TITLE
Error Recovery Improvements

### DIFF
--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -242,7 +242,7 @@ const SendbirdSDK = ({
   });
 
   useUnmount(() => {
-    if (typeof sdk?.disconnect === 'function') {
+    if (typeof sdk.disconnect === 'function') {
       disconnectSdk({
         logger,
         sdkDispatcher,
@@ -250,7 +250,7 @@ const SendbirdSDK = ({
         sdk,
       });
     }
-  }, [sdk?.disconnect]);
+  }, [sdk.disconnect]);
 
   // to create a pubsub to communicate between parent and child
   useEffect(() => {

--- a/src/lib/Sendbird.tsx
+++ b/src/lib/Sendbird.tsx
@@ -242,7 +242,7 @@ const SendbirdSDK = ({
   });
 
   useUnmount(() => {
-    if (typeof sdk.disconnect === 'function') {
+    if (typeof sdk?.disconnect === 'function') {
       disconnectSdk({
         logger,
         sdkDispatcher,
@@ -250,7 +250,7 @@ const SendbirdSDK = ({
         sdk,
       });
     }
-  }, [sdk.disconnect]);
+  }, [sdk?.disconnect]);
 
   // to create a pubsub to communicate between parent and child
   useEffect(() => {

--- a/src/lib/hooks/useConnect/setupConnection.ts
+++ b/src/lib/hooks/useConnect/setupConnection.ts
@@ -84,6 +84,7 @@ export async function setUpConnection({
   return new Promise((resolve, reject) => {
     logger?.info?.('SendbirdProvider | useConnect/setupConnection/init', { userId, appId });
     const onConnectionFailed = eventHandlers?.connection?.onFailed;
+    const onConnectionSucceeded = eventHandlers?.connection?.onSucceeded;
     sdkDispatcher({ type: SET_SDK_LOADING, payload: true });
 
     if (userId && appId) {
@@ -125,6 +126,7 @@ export async function setUpConnection({
       newSdk.addExtension('sb_uikit', APP_VERSION_STRING);
 
       const connectCbSuccess = async (user: User) => {
+        onConnectionSucceeded?.(user);
         logger?.info?.('SendbirdProvider | useConnect/setupConnection/connectCbSuccess', user);
         sdkDispatcher({ type: INIT_SDK, payload: newSdk });
         userDispatcher({ type: INIT_USER, payload: user });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface SBUEventHandlers {
   },
   connection?: {
     onFailed?(error: SendbirdError): void;
+    onSucceeded?(user: User): void;
   },
   request?: {
     onFailed?(error: SendbirdError | Error, context?: {

--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -107,7 +107,7 @@ export interface ChannelListProviderInterface extends ChannelListProviderProps {
   channelListDispatcher: React.Dispatch<ChannelListActionTypes>;
   channelSource: GroupChannelListQuerySb | null;
   hardReload: () => void;
-  fetchChannelList: () => void;
+  fetchChannelList: (resolveValue?: boolean) => void;
 }
 
 const ChannelListContext = React.createContext<ChannelListProviderInterface | null>({

--- a/src/modules/ChannelList/context/hooks/useFetchChannelList.ts
+++ b/src/modules/ChannelList/context/hooks/useFetchChannelList.ts
@@ -28,7 +28,7 @@ export const useFetchChannelList = ({
   eventHandlers,
   markAsDeliveredScheduler,
 }: StaticProps) => {
-  return useCallback(async () => {
+  return useCallback(async (resolveValue?: boolean) => {
     if (!channelSource?.hasNext) {
       logger.info('ChannelList: not able to fetch');
       return;
@@ -54,6 +54,9 @@ export const useFetchChannelList = ({
           }
         });
       }
+      if (resolveValue) {
+        return channelList;
+      }
     } catch (error) {
       logger.error('ChannelList: failed fetch', { error });
       eventHandlers?.request?.onFailed?.(error);
@@ -61,6 +64,9 @@ export const useFetchChannelList = ({
         type: channelListActions.FETCH_CHANNELS_FAILURE,
         payload: error,
       });
+      if (resolveValue) {
+        throw error
+      }
     }
   }, [
     channelSource,


### PR DESCRIPTION
## Description

As part of our error recovery system, we made some small changes to UIKit.

- Add onConnectionSucceeded eventHandler
  - This allows use to **promiseify** the whole connection flow
- Add  an argument to useFetchChannelList to properly resolve a promise
  - This allows use to properly retry fetching the channel list with our error recovery system

## Test Plan

1. Build UIKit with these changes locally
2. Add the dist folder as a dependency for gather-town
3. Add an on onConnectionSucceeded event handler with a console.log
4. Start chat and verify the onConnectionSucceeded console.log fires
5. Add `const { fetchChannelList } = useChannelListContext();` under the ChannelListProvider
6. Call  `await fetchChannelList(true);`
7. Observe that it returns the channel list
8. Turn off your internet
9. Call  `await fetchChannelList(true);`
10. Observe that it rejects the promise

