### PR TITLE
Expose custom render props for Thread customization

### DIFF
--- a/src/modules/GroupChannel/components/MessageList/index.tsx
+++ b/src/modules/GroupChannel/components/MessageList/index.tsx
@@ -269,6 +269,10 @@ export const MessageList = ({
                       currentUserId: store.config.userId
                     });
                     const isOutgoingMessage = isSendableMessage(message) && message.sender.userId === store.config.userId;
+
+                    // Don't show threaded message in the channel message list
+                    if (message.parentMessageId || message.parentMessage) return null;
+
                     return (
                       <MessageProvider message={message} key={getComponentKeyFromMessage(message)} isByMe={isOutgoingMessage}>
                         {renderMessage({

--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -35,6 +35,7 @@ export interface ThreadUIProps {
   renderCustomSeparator?: () => React.ReactElement;
   renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
   renderThreadListPlaceHolder?: (type: ThreadListStateTypes) => React.ReactElement;
+  renderReplyCount?: (replyCount: number) => React.ReactElement
 }
 
 const ThreadUI: React.FC<ThreadUIProps> = ({
@@ -48,6 +49,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
   renderFileUploadIcon,
   renderVoiceMessageIcon,
   renderSendMessageIcon,
+  renderReplyCount
 }: ThreadUIProps): React.ReactElement => {
   const {
     stores,
@@ -161,6 +163,7 @@ const ThreadUI: React.FC<ThreadUIProps> = ({
         </MessageProvider>
         {
           replyCount > 0 && (
+            renderReplyCount ? renderReplyCount(replyCount) :
             <div className="sendbird-thread-ui__reply-counts">
               <Label
                 type={LabelTypography.BODY_1}

--- a/src/modules/Thread/index.tsx
+++ b/src/modules/Thread/index.tsx
@@ -36,6 +36,7 @@ const Thread = (props: ThreadProps) => {
     renderFileUploadIcon,
     renderVoiceMessageIcon,
     renderSendMessageIcon,
+    renderReplyCount
   } = props;
   return (
     <div className={`sendbird-thread ${className}`}>
@@ -61,6 +62,7 @@ const Thread = (props: ThreadProps) => {
           renderFileUploadIcon={renderFileUploadIcon}
           renderVoiceMessageIcon={renderVoiceMessageIcon}
           renderSendMessageIcon={renderSendMessageIcon}
+          renderReplyCount={renderReplyCount}
         />
       </ThreadProvider>
     </div>

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useContext, useMemo, useRef, useState } from 'react';
+import React, { ReactElement, ReactNode, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import format from 'date-fns/format';
 import './index.scss';
 
@@ -32,7 +32,7 @@ import { Feedback, FeedbackRating } from '@sendbird/chat/message';
 import useLongPress from '../../hooks/useLongPress';
 import MobileMenu from '../MobileMenu';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
-import ThreadReplies from '../ThreadReplies';
+import ThreadReplies, { ThreadRepliesProps } from '../ThreadReplies';
 import { ThreadReplySelectType } from '../../modules/Channel/context/const';
 import { Nullable, ReplyType } from '../../types';
 import { deleteNullish, noop } from '../../utils/utils';
@@ -85,6 +85,8 @@ export interface MessageContentProps {
   renderEmojiMenu?: (props: MessageEmojiMenuProps) => ReactNode;
   renderEmojiReactions?: (props: EmojiReactionsProps) => ReactNode;
   renderMobileMenuOnLongPress?: (props: MobileBottomSheetProps) => React.ReactElement;
+  renderThreadReplies?:(props: ThreadRepliesProps) => React.ReactElement;
+  hideThreadReplies?: boolean;
 }
 
 export default function MessageContent(props: MessageContentProps): ReactElement {
@@ -115,6 +117,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     onQuoteMessageClick,
     onMessageHeightChange,
     onBeforeDownloadFileMessage,
+    hideThreadReplies
   } = props;
 
   // Public props for customization
@@ -126,6 +129,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     renderEmojiMenu = (props: MessageEmojiMenuProps) => <MessageEmojiMenu {...props} />,
     renderEmojiReactions = (props: EmojiReactionsProps) => <EmojiReactions {...props} />,
     renderMobileMenuOnLongPress = (props: MobileBottomSheetProps) => <MobileMenu {...props} />,
+    renderThreadReplies = (props: ThreadRepliesProps) => <ThreadReplies {...props}/>
   } = deleteNullish(props);
 
   const { dateLocale } = useLocalization();
@@ -177,7 +181,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   const useReplyingClassName = useReplying ? 'use-quote' : '';
 
   // Thread replies
-  const displayThreadReplies = message?.threadInfo?.replyCount > 0 && replyType === 'THREAD';
+  const displayThreadReplies = message?.threadInfo?.replyCount > 0 && replyType === 'THREAD' && !hideThreadReplies;
 
   // Feedback buttons
   const isFeedbackMessage = !isByMe
@@ -229,6 +233,9 @@ export default function MessageContent(props: MessageContentProps): ReactElement
       setShowFeedbackModal(true);
     }
   };
+
+  const onThreadRepliesClick = useCallback(() => {
+    isSendableMessage(message) && onReplyInThread?.({ message })} , [message])
 
   // onMouseDown: (e: React.MouseEvent<T>) => void;
   // onTouchStart: (e: React.TouchEvent<T>) => void;
@@ -406,12 +413,8 @@ export default function MessageContent(props: MessageContentProps): ReactElement
         />}
         {/* thread replies */}
         {showThreadReplies && (
-          <ThreadReplies
-            className="sendbird-message-content__middle__thread-replies"
-            threadInfo={message?.threadInfo}
-            onClick={() => onReplyInThread?.({ message })}
-            ref={threadRepliesRef}
-          />
+          renderThreadReplies({threadInfo:message?.threadInfo, onClick: onThreadRepliesClick})
+   
         )}
         {/* Feedback buttons */}
         {

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -138,7 +138,6 @@ export default function MessageContent(props: MessageContentProps): ReactElement
   const onPressUserProfileHandler = eventHandlers?.reaction?.onPressUserProfile;
   const contentRef = useRef(null);
   const timestampRef = useRef(null);
-  const threadRepliesRef = useRef(null);
   const feedbackButtonsRef = useRef(null);
   const { isMobile } = useMediaQueryContext();
   const [showMenu, setShowMenu] = useState(false);
@@ -210,9 +209,6 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     let sum = 2;
     if (timestampRef.current && isTimestampBottom) {
       sum += 4 + timestampRef.current.clientHeight;
-    }
-    if (threadRepliesRef.current) {
-      sum += 4 + threadRepliesRef.current.clientHeight;
     }
     if (feedbackButtonsRef.current) {
       sum += 4 + feedbackButtonsRef.current.clientHeight;

--- a/src/ui/MessageItemMenu/index.tsx
+++ b/src/ui/MessageItemMenu/index.tsx
@@ -231,7 +231,7 @@ export function MessageMenu(props: MessageMenuProps): ReactElement {
                       closeDropdown();
                     }
                   },
-                  disable: typeof disableDeleteMessage === 'boolean' ? disableDeleteMessage : message?.threadInfo?.replyCount > 0,
+                  disable: disableDeleteMessage,
                   dataSbId: 'ui_message_item_menu_delete',
                   text: stringSet.MESSAGE_MENU__DELETE,
                 })}

--- a/src/ui/ThreadReplies/index.tsx
+++ b/src/ui/ThreadReplies/index.tsx
@@ -19,7 +19,6 @@ export function ThreadReplies(
     threadInfo,
     onClick,
   }: ThreadRepliesProps,
-  ref?: RefObject<HTMLDivElement>,
 ): React.ReactElement {
   const {
     mostRepliedUsers = [],
@@ -38,7 +37,6 @@ export function ThreadReplies(
         onClick(e);
         e?.stopPropagation();
       }}
-      ref={ref}
     >
       <div className="sendbird-ui-thread-replies__user-profiles">
         {mostRepliedUsers.slice(0, 4).map((user) => {


### PR DESCRIPTION
## Description
Exposes 
- renderReplyCount: customizes the UI that summarizes the number of replies in the thread
- renderThreadReplies: on each message component, the UI that allows the user to click on the thread
- hideThreadReplies: in the case of the parent thread message, we want to hide these replies (but still use the same message component)
- always show "delete" button -> we need add custom logic to handle this for parent thread messages

## Test Plan
hideThreadReplies true:
![Screenshot 2024-06-20 at 8 26 59 PM](https://github.com/gathertown/sendbird-uikit-react/assets/51099886/010f96df-f4e2-49f9-81f8-129ad6ebe5e3)

replace renderReplyCount with a button:
![Screenshot 2024-06-20 at 8 34 24 PM](https://github.com/gathertown/sendbird-uikit-react/assets/51099886/b322cf3b-8f90-4f9a-9924-82db0e4acfb5)

replace renderThreadReplies with a button:
![Screenshot 2024-06-20 at 8 27 44 PM](https://github.com/gathertown/sendbird-uikit-react/assets/51099886/501cf652-bbe7-47e9-9f9b-5b40531a1ab2)
