### PR TITLE
Extend Message components for better mentions in message feed.

### DIFF
--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -17,7 +17,7 @@ import type { SendableMessageType } from '../../../utils';
 import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { ThreadReplySelectType } from './const';
-import { RenderUserProfileProps, ReplyType } from '../../../types';
+import { MentionLabelProps, RenderUserProfileProps, ReplyType } from '../../../types';
 import useToggleReactionCallback from './hooks/useToggleReactionCallback';
 import { getCaseResolvedReplyType, getCaseResolvedThreadReplySelectType } from '../../../lib/utils/resolvedReplyType';
 import { getMessageTopOffset, isContextMenuClosed } from './utils';
@@ -77,6 +77,7 @@ interface ContextBaseType {
   // Render
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   renderUserMentionItem?: (props: { user: User }) => JSX.Element;
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export interface GroupChannelContextType extends ContextBaseType, MessageListDataSourceWithoutActions, MessageActions {
@@ -136,6 +137,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
     onSearchClick,
     onQuoteMessageClick,
     renderUserMentionItem,
+    renderMessageMentionLabel,
   } = props;
 
   // Global context
@@ -420,6 +422,7 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
         onQuoteMessageClick,
         // ## Custom render
         renderUserMentionItem,
+        renderMessageMentionLabel,
 
         // Internal Interface
         currentChannel,

--- a/src/modules/GroupChannel/context/GroupChannelProvider.tsx
+++ b/src/modules/GroupChannel/context/GroupChannelProvider.tsx
@@ -17,7 +17,7 @@ import type { SendableMessageType } from '../../../utils';
 import { UserProfileProvider, UserProfileProviderProps } from '../../../lib/UserProfileContext';
 import useSendbirdStateContext from '../../../hooks/useSendbirdStateContext';
 import { ThreadReplySelectType } from './const';
-import { MentionLabelProps, RenderUserProfileProps, ReplyType } from '../../../types';
+import { RenderUserProfileProps, ReplyType } from '../../../types';
 import useToggleReactionCallback from './hooks/useToggleReactionCallback';
 import { getCaseResolvedReplyType, getCaseResolvedThreadReplySelectType } from '../../../lib/utils/resolvedReplyType';
 import { getMessageTopOffset, isContextMenuClosed } from './utils';
@@ -77,7 +77,6 @@ interface ContextBaseType {
   // Render
   renderUserProfile?: (props: RenderUserProfileProps) => React.ReactElement;
   renderUserMentionItem?: (props: { user: User }) => JSX.Element;
-  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export interface GroupChannelContextType extends ContextBaseType, MessageListDataSourceWithoutActions, MessageActions {
@@ -137,7 +136,6 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
     onSearchClick,
     onQuoteMessageClick,
     renderUserMentionItem,
-    renderMessageMentionLabel,
   } = props;
 
   // Global context
@@ -422,7 +420,6 @@ export const GroupChannelProvider = (props: GroupChannelProviderProps) => {
         onQuoteMessageClick,
         // ## Custom render
         renderUserMentionItem,
-        renderMessageMentionLabel,
 
         // Internal Interface
         currentChannel,

--- a/src/modules/Message/components/TextFragment/index.tsx
+++ b/src/modules/Message/components/TextFragment/index.tsx
@@ -10,6 +10,7 @@ import { USER_MENTION_PREFIX } from '../../consts';
 import LinkLabel from '../../../../ui/LinkLabel';
 import { LabelTypography } from '../../../../ui/Label';
 import { getWhiteSpacePreservedText } from '../../utils/tokens/tokenize';
+import { useGroupChannelContext } from '../../../GroupChannel/context/GroupChannelProvider';
 
 export type TextFragmentProps = {
   tokens: Token[];
@@ -19,6 +20,7 @@ export default function TextFragment({
   tokens,
 }: TextFragmentProps): React.ReactElement {
   const messageStore = useMessageContext();
+  const { renderMessageMentionLabel } = useGroupChannelContext();
 
   const message = messageStore?.message as UserMessage;
   const isByMe = messageStore?.isByMe;
@@ -31,13 +33,20 @@ export default function TextFragment({
         return match(token.type)
           .with(TOKEN_TYPES.mention, () => (
             <span className="sendbird-word" key={key}>
+              {renderMessageMentionLabel ? renderMessageMentionLabel({
+                mentionTemplate: USER_MENTION_PREFIX,
+                // @ts-ignore
+                mentionedUserId: token.userId,
+                mentionedUserNickname: token.value,
+                isByMe: isByMe
+              }) :
               <MentionLabel
                 mentionTemplate={USER_MENTION_PREFIX}
                 // @ts-ignore
                 mentionedUserId={token.userId}
                 mentionedUserNickname={token.value}
                 isByMe={isByMe}
-              />
+              />}
             </span>
           ))
           .with(TOKEN_TYPES.url, () => (

--- a/src/modules/Message/components/TextFragment/index.tsx
+++ b/src/modules/Message/components/TextFragment/index.tsx
@@ -20,6 +20,7 @@ export default function TextFragment({
   tokens,
 }: TextFragmentProps): React.ReactElement {
   const messageStore = useMessageContext();
+  // fork note: custom render property
   const { renderMessageMentionLabel } = useGroupChannelContext();
 
   const message = messageStore?.message as UserMessage;

--- a/src/modules/Message/components/TextFragment/index.tsx
+++ b/src/modules/Message/components/TextFragment/index.tsx
@@ -11,17 +11,18 @@ import LinkLabel from '../../../../ui/LinkLabel';
 import { LabelTypography } from '../../../../ui/Label';
 import { getWhiteSpacePreservedText } from '../../utils/tokens/tokenize';
 import { useGroupChannelContext } from '../../../GroupChannel/context/GroupChannelProvider';
+import { MentionLabelProps } from '../../../../types';
 
 export type TextFragmentProps = {
   tokens: Token[];
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 };
 
 export default function TextFragment({
   tokens,
+  renderMessageMentionLabel
 }: TextFragmentProps): React.ReactElement {
   const messageStore = useMessageContext();
-  // fork note: custom render property
-  const { renderMessageMentionLabel } = useGroupChannelContext();
 
   const message = messageStore?.message as UserMessage;
   const isByMe = messageStore?.isByMe;

--- a/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
+++ b/src/modules/Thread/components/ParentMessageInfo/ParentMessageInfoItem.tsx
@@ -37,12 +37,15 @@ import { useThreadMessageKindKeySelector } from '../../../Channel/context/hooks/
 import { useFileInfoListWithUploaded } from '../../../Channel/context/hooks/useFileInfoListWithUploaded';
 import { Colors } from '../../../../utils/color';
 import type { OnBeforeDownloadFileMessageType } from '../../../GroupChannel/context/GroupChannelProvider';
+import { MentionLabelProps } from '../../../../types';
 
 export interface ParentMessageInfoItemProps {
   className?: string;
   message: SendableMessageType;
   showFileViewer?: (bool: boolean) => void;
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
+
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export default function ParentMessageInfoItem({
@@ -50,6 +53,7 @@ export default function ParentMessageInfoItem({
   message,
   showFileViewer,
   onBeforeDownloadFileMessage = null,
+  renderMessageMentionLabel
 }: ParentMessageInfoItemProps): ReactElement {
   const { stores, config, eventHandlers } = useSendbirdStateContext?.() || {};
   const { logger } = config;
@@ -131,7 +135,7 @@ export default function ParentMessageInfoItem({
           type={LabelTypography.BODY_1}
           color={LabelColors.ONBACKGROUND_1}
         >
-          <TextFragment tokens={tokens} />
+          <TextFragment tokens={tokens} renderMessageMentionLabel={renderMessageMentionLabel} />
           {isEditedMessage(message) && (
             <Label
               className="sendbird-parent-message-info-item__text-message edited"

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface RenderUserProfileProps {
   avatarRef: MutableRefObject<any>;
 }
 
+// fork note: used in the TextFragment component, the props needed to render
+// a custom mention in the message feed using renderMessageMentionLabel
 export interface MentionLabelProps {
   mentionTemplate: string;
   mentionedUserId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,13 @@ export interface RenderUserProfileProps {
   avatarRef: MutableRefObject<any>;
 }
 
+export interface MentionLabelProps {
+  mentionTemplate: string;
+  mentionedUserId: string;
+  mentionedUserNickname: string;
+  isByMe: boolean;
+}
+
 export interface SendBirdProviderConfig {
   logLevel?: 'debug' | 'warning' | 'error' | 'info' | 'all' | Array<string>;
   userMention?: {

--- a/src/ui/MessageContent/MessageBody/index.tsx
+++ b/src/ui/MessageContent/MessageBody/index.tsx
@@ -17,7 +17,7 @@ import UnknownMessageItemBody from '../../UnknownMessageItemBody';
 import { useThreadMessageKindKeySelector } from '../../../modules/Channel/context/hooks/useThreadMessageKindKeySelector';
 import { useFileInfoListWithUploaded } from '../../../modules/Channel/context/hooks/useFileInfoListWithUploaded';
 import { SendBirdStateConfig } from '../../../lib/types';
-import { Nullable, SendbirdTheme } from '../../../types';
+import { MentionLabelProps, Nullable, SendbirdTheme } from '../../../types';
 import { GroupChannel } from '@sendbird/chat/groupChannel';
 import { match } from 'ts-pattern';
 import TemplateMessageItemBody from '../../TemplateMessageItemBody';
@@ -33,6 +33,7 @@ export interface MessageBodyProps {
   onTemplateMessageRenderedCallback?: (renderedTemplateBodyType: RenderedTemplateBodyType) => void;
   onMessageHeightChange?: () => void;
   onBeforeDownloadFileMessage?: OnBeforeDownloadFileMessageType;
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 
   mouseHover: boolean;
   isMobile: boolean;
@@ -49,6 +50,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
     onMessageHeightChange,
     onTemplateMessageRenderedCallback,
     onBeforeDownloadFileMessage,
+    renderMessageMentionLabel,
 
     mouseHover,
     isMobile,
@@ -86,6 +88,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         isMentionEnabled={config?.isMentionEnabled || false}
         isReactionEnabled={isReactionEnabledInChannel}
         onMessageHeightChange={onMessageHeightChange}
+        renderMessageMentionLabel={renderMessageMentionLabel}
       />
     ))
     .when(isTextMessage, () => (
@@ -96,6 +99,7 @@ export default function MessageBody(props: MessageBodyProps): ReactElement {
         mouseHover={mouseHover}
         isMentionEnabled={config?.isMentionEnabled || false}
         isReactionEnabled={isReactionEnabledInChannel}
+        renderMessageMentionLabel={renderMessageMentionLabel}
       />
     ))
     .when((message) => getUIKitMessageType(message) === messageTypes.FILE, () => (

--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -34,7 +34,7 @@ import MobileMenu from '../MobileMenu';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
 import ThreadReplies, { ThreadRepliesProps } from '../ThreadReplies';
 import { ThreadReplySelectType } from '../../modules/Channel/context/const';
-import { Nullable, ReplyType } from '../../types';
+import { MentionLabelProps, Nullable, ReplyType } from '../../types';
 import { deleteNullish, noop } from '../../utils/utils';
 import MessageProfile, { MessageProfileProps } from './MessageProfile';
 import MessageBody, { MessageBodyProps } from './MessageBody';
@@ -87,6 +87,7 @@ export interface MessageContentProps {
   renderMobileMenuOnLongPress?: (props: MobileBottomSheetProps) => React.ReactElement;
   renderThreadReplies?:(props: ThreadRepliesProps) => React.ReactElement;
   hideThreadReplies?: boolean;
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export default function MessageContent(props: MessageContentProps): ReactElement {
@@ -117,7 +118,8 @@ export default function MessageContent(props: MessageContentProps): ReactElement
     onQuoteMessageClick,
     onMessageHeightChange,
     onBeforeDownloadFileMessage,
-    hideThreadReplies
+    hideThreadReplies,
+    renderMessageMentionLabel,
   } = props;
 
   // Public props for customization
@@ -354,6 +356,7 @@ export default function MessageContent(props: MessageContentProps): ReactElement
               isByMe,
               onTemplateMessageRenderedCallback,
               onBeforeDownloadFileMessage,
+              renderMessageMentionLabel
             })
           }
           {/* reactions */}

--- a/src/ui/OGMessageItemBody/index.tsx
+++ b/src/ui/OGMessageItemBody/index.tsx
@@ -16,6 +16,7 @@ import TextFragment from '../../modules/Message/components/TextFragment';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
 import { OG_MESSAGE_BODY_CLASSNAME } from './consts';
 import { useMediaQueryContext } from '../../lib/MediaQueryContext';
+import { MentionLabelProps } from '../../types';
 
 interface Props {
   className?: string | Array<string>;
@@ -25,6 +26,7 @@ interface Props {
   isMentionEnabled?: boolean;
   isReactionEnabled?: boolean;
   onMessageHeightChange?: () => void;
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export default function OGMessageItemBody({
@@ -35,6 +37,7 @@ export default function OGMessageItemBody({
   isMentionEnabled = false,
   isReactionEnabled = false,
   onMessageHeightChange = () => { /* noop */ },
+  renderMessageMentionLabel,
 }: Props): ReactElement {
   const imageRef = useRef<HTMLDivElement>(null);
   const { stringSet } = useContext(LocalizationContext);
@@ -74,7 +77,7 @@ export default function OGMessageItemBody({
         color={isByMe ? LabelColors.ONCONTENT_1 : LabelColors.ONBACKGROUND_1}
       >
         <div className={OG_MESSAGE_BODY_CLASSNAME}>
-          <TextFragment tokens={tokens} />
+          <TextFragment tokens={tokens} renderMessageMentionLabel={renderMessageMentionLabel}/>
           {
             isEditedMessage(message) && (
               <Label

--- a/src/ui/TextMessageItemBody/index.tsx
+++ b/src/ui/TextMessageItemBody/index.tsx
@@ -8,6 +8,7 @@ import { LocalizationContext } from '../../lib/LocalizationContext';
 import { tokenizeMessage } from '../../modules/Message/utils/tokens/tokenize';
 import TextFragment from '../../modules/Message/components/TextFragment';
 import { TEXT_MESSAGE_BODY_CLASSNAME } from './consts';
+import { MentionLabelProps } from '../../types';
 
 interface Props {
   className?: string | Array<string>;
@@ -16,6 +17,8 @@ interface Props {
   mouseHover?: boolean;
   isMentionEnabled?: boolean;
   isReactionEnabled?: boolean;
+
+  renderMessageMentionLabel?: (props: MentionLabelProps) => JSX.Element;
 }
 
 export default function TextMessageItemBody({
@@ -25,6 +28,7 @@ export default function TextMessageItemBody({
   mouseHover = false,
   isMentionEnabled = false,
   isReactionEnabled = false,
+  renderMessageMentionLabel
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const isMessageMentioned = isMentionEnabled
@@ -53,7 +57,7 @@ export default function TextMessageItemBody({
         mouseHover ? 'mouse-hover' : '',
         (isReactionEnabled && message?.reactions?.length > 0) ? 'reactions' : '',
       ])}>
-        <TextFragment tokens={tokens} />
+        <TextFragment tokens={tokens} renderMessageMentionLabel={renderMessageMentionLabel} />
         {
           isEditedMessage(message) && (
             <Label


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-7693/implement-mentions-in-message-feed

This is the fork changes needed to support custom mentions in message feed. It basically makes the code more extensible. To see how these changes are used, refer to this PR: https://github.com/gathertown/gather-town/pull/25670

## Test Plan

- [x] Build and use the package locally with these changes; Send messages with @-mentions by using temporary components that support it; Use code from PR https://github.com/gathertown/gather-town/pull/25670. Validate that the mentions work as expected:


<img width="379" alt="Screenshot 2024-06-24 at 22 41 47" src="https://github.com/gathertown/sendbird-uikit-react/assets/6392953/ee0d2af0-4525-4b4a-b58e-26e6b9da36b0">
<img width="394" alt="Screenshot 2024-06-24 at 23 36 53" src="https://github.com/gathertown/sendbird-uikit-react/assets/6392953/30864350-7264-4702-a91b-2718a3a9c605">

