### PR TITLE
Improve and Extend Input classes for Mentions and Drafts.

### DIFF
--- a/rollup.module-exports.mjs
+++ b/rollup.module-exports.mjs
@@ -102,6 +102,7 @@ export default {
   'GroupChannel/components/SuggestedMentionList': 'src/modules/GroupChannel/components/SuggestedMentionList/index.tsx',
   'GroupChannel/components/SuggestedReplies': 'src/modules/GroupChannel/components/SuggestedReplies/index.tsx',
   'GroupChannel/hooks/useHandleUploadFiles': 'src/modules/GroupChannel/components/MessageInputWrapper/useHandleUploadFiles.tsx',
+  'GroupChannel/components/SuggestedMentionListView': 'src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx',
 
   // 'GroupChannel/components/MessageFeedbackModal': 'src/modules/GroupChannel/components/MessageFeedbackModal/index.tsx', // TODO: move to UI
 

--- a/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
+++ b/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedMentionListView.tsx
@@ -28,7 +28,8 @@ export interface SuggestedMentionListViewProps {
   inputEvent?: React.KeyboardEvent<HTMLDivElement>;
 }
 
-const DEBOUNCING_TIME = 300;
+// fork note: 300 (default) gave a bad UX
+const DEBOUNCING_TIME = 100;
 
 export const SuggestedMentionListView = (props: SuggestedMentionListViewProps) => {
   const {
@@ -128,7 +129,8 @@ export const SuggestedMentionListView = (props: SuggestedMentionListViewProps) =
     lastSearchString,
   ]);
 
-  if (!ableAddMention && currentMemberList.length === 0) {
+  // fork note: bug fix, it was showing an ugly empty list
+  if (!ableAddMention || currentMemberList.length === 0) {
     return null;
   }
 

--- a/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedUserMentionItem.tsx
+++ b/src/modules/GroupChannel/components/SuggestedMentionList/SuggestedUserMentionItem.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, useContext, useEffect, useMemo, useRef } from 'react';
+import React, { MutableRefObject, useContext, useEffect, useRef } from 'react';
 import type { Member } from '@sendbird/chat/groupChannel';
 import type { User } from '@sendbird/chat';
 
@@ -43,24 +43,21 @@ function SuggestedUserMentionItem(props: SuggestedUserMentionItemProps): JSX.Ele
       scrollRef.current.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     }
   }, [isFocused]);
-  const customMentionItem = useMemo(() => {
-    if (renderUserMentionItem) {
-      return (
-        <div
-          className="sendbird-mention-suggest-list__user-item"
-          onClick={(event) => onClick?.({ event, member: (member as Member), itemRef: scrollRef })}
-          onMouseOver={(event) => onMouseOver?.({ event, member: (member as Member), itemRef: scrollRef })}
-          onMouseMove={(event) => onMouseMove?.({ event, member: (member as Member), itemRef: scrollRef })}
-          key={member?.userId || uuidv4()}
-          ref={scrollRef}
-        >
-          {renderUserMentionItem({ user: member })}
-        </div>
-      );
-    }
-  }, [renderUserMentionItem]);
-  if (customMentionItem) {
-    return customMentionItem;
+  if (renderUserMentionItem) {
+    // fork note: removed useMemo to make sure the component is rerendered properly on state changes (isFocused, mouse handlers, etc)
+    // also now using the same 'focused' class name logic as the default renderer
+    return (
+      <div
+      className={`sendbird-mention-suggest-list__user-item ${isFocused ? 'focused' : ''}`}
+        onClick={(event) => onClick?.({ event, member: (member as Member), itemRef: scrollRef })}
+        onMouseOver={(event) => onMouseOver?.({ event, member: (member as Member), itemRef: scrollRef })}
+        onMouseMove={(event) => onMouseMove?.({ event, member: (member as Member), itemRef: scrollRef })}
+        key={member?.userId || uuidv4()}
+        ref={scrollRef}
+      >
+        {renderUserMentionItem({ user: member })}
+      </div>
+    );
   }
   return (
     <div

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,15 @@ export interface MentionLabelProps {
   isByMe: boolean;
 }
 
+// fork note: the minimum amount of information needed to save and restore
+// an *unsent* message as a draft
+export interface DraftMessage {
+  messageId: number | null;
+  message: string;
+  mentionedUsers: User[] | null;
+  mentionedMessageTemplate: string | null;
+}
+
 export interface SendBirdProviderConfig {
   logLevel?: 'debug' | 'warning' | 'error' | 'info' | 'all' | Array<string>;
   userMention?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,10 +52,10 @@ export interface MentionLabelProps {
 // fork note: the minimum amount of information needed to save and restore
 // an *unsent* message as a draft
 export interface DraftMessage {
-  messageId: number | null;
-  message: string;
-  mentionedUsers: User[] | null;
-  mentionedMessageTemplate: string | null;
+  messageId?: number | null;
+  message?: string | null;
+  mentionedUsers?: User[] | null;
+  mentionedMessageTemplate?: string | null;
 }
 
 export interface SendBirdProviderConfig {

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -20,8 +20,15 @@ export function usePaste({
   setHeight,
   channel,
   setMentionedUsers,
+  customOnPaste,
+  onChange
 }: DynamicProps): (e: React.ClipboardEvent<HTMLDivElement>) => void {
   return useCallback((e) => {
+    if (customOnPaste && customOnPaste(e)) {
+      // custom logic already handled input, exit here
+      return;
+    }
+
     e.preventDefault();
     const html = e.clipboardData.getData('text/html');
     // simple text, continue as normal
@@ -30,6 +37,7 @@ export function usePaste({
       document.execCommand('insertHTML', false, sanitizeString(text));
       setIsInput(true);
       setHeight();
+      onChange?.()
       return;
     }
 
@@ -46,6 +54,7 @@ export function usePaste({
       pasteNode.remove();
       setIsInput(true);
       setHeight();
+      onChange?.()
       return;
     }
 
@@ -60,7 +69,8 @@ export function usePaste({
     pasteNode.remove();
     setIsInput(true);
     setHeight();
-  }, [ref, setIsInput, setHeight, channel, setMentionedUsers]);
+    onChange?.()
+  }, [ref, setIsInput, setHeight, channel, setMentionedUsers, customOnPaste]);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#dragging_links

--- a/src/ui/MessageInput/hooks/usePaste/types.ts
+++ b/src/ui/MessageInput/hooks/usePaste/types.ts
@@ -17,7 +17,7 @@ export type DynamicProps = {
   /* fork notes: custom callbacks */
   // called before any uikit code when there's a paste event.
   // if callback returns true, uikit's code will not be executed
-  customOnPaste: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
+  customOnPaste?: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
   // called if there was any change to the value
-  onChange: () => void;
+  onChange?: () => void;
 };

--- a/src/ui/MessageInput/hooks/usePaste/types.ts
+++ b/src/ui/MessageInput/hooks/usePaste/types.ts
@@ -13,4 +13,11 @@ export type DynamicProps = {
   setMentionedUsers: React.Dispatch<React.SetStateAction<User[]>>;
   setIsInput: React.Dispatch<React.SetStateAction<boolean>>;
   setHeight: () => void;
+
+  /* fork notes: custom callbacks */
+  // called before any uikit code when there's a paste event.
+  // if callback returns true, uikit's code will not be executed
+  customOnPaste: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
+  // called if there was any change to the value
+  onChange: () => void;
 };

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -277,6 +277,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       }
       setIsInput(textField?.textContent?.trim().length > 0);
       setHeight();
+      // fork note: force the cursor to the end if loading a draft message or editing
       moveCursorToEnd(textField);
     }
   }, [isEdit, message]);

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -243,7 +243,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         /* mention enabled */
         const { mentionedUsers = [] } = message;
         const tokens = tokenizeMessage({
-          messageText: message?.mentionedMessageTemplate,
+          messageText: message?.mentionedMessageTemplate || "",
           mentionedUsers,
         });
         textField.innerHTML = tokens

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -25,6 +25,9 @@ import { GroupChannel } from '@sendbird/chat/groupChannel';
 import { User } from '@sendbird/chat';
 import { OpenChannel } from '@sendbird/chat/openChannel';
 import { UserMessage } from '@sendbird/chat/message';
+import { DraftMessage } from '../../types';
+
+import { useDebounce } from '../../hooks/useDebounce';
 
 const TEXT_FIELD_ID = 'sendbird-message-input-text-field';
 const LINE_HEIGHT = 76;
@@ -40,6 +43,16 @@ const displayCaret = (element: HTMLInputElement, position: number) => {
   range.collapse(true);
   sel.removeAllRanges();
   sel.addRange(range);
+  element.focus();
+};
+
+const moveCursorToEnd = (element: HTMLInputElement) => {
+  const range = document.createRange();
+  const selection = window.getSelection();
+  range.setStart(element, element.childNodes.length);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
   element.focus();
 };
 
@@ -61,7 +74,7 @@ const initialTargetStringInfo = {
 
 type MessageInputProps = {
   channel: GroupChannel | OpenChannel;
-  message?: UserMessage;
+  message?: UserMessage | DraftMessage;
   value?: null | string;
   className?: string | string[];
   messageFieldId?: string;
@@ -91,6 +104,12 @@ type MessageInputProps = {
   renderSendMessageIcon?: () => React.ReactNode;
   setMentionedUsers?: React.Dispatch<React.SetStateAction<User[]>>;
   acceptableMimeTypes?: string[];
+
+  // custom props
+  inputAreaPrefix?: React.ReactNode;
+  inputAreaButtons?: React.ReactNode;
+  onPaste?: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
+  onDraftChange?: (draftMessage: DraftMessage) => void;
 };
 const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((props, externalRef) => {
   const {
@@ -124,6 +143,12 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     renderSendMessageIcon = noop,
     setMentionedUsers = noop,
     acceptableMimeTypes,
+
+    // custom props
+    inputAreaPrefix,
+    inputAreaButtons,
+    onDraftChange,
+    onPaste: customOnPaste,
   } = props;
 
   const internalRef = (externalRef && 'current' in externalRef) ? externalRef : null;
@@ -167,6 +192,22 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     [],
   );
 
+  // fork notes: process the current input to save as draft
+  const processDraftChangeImmediate = useCallback(() => {
+    const textField = internalRef?.current;
+    if (!textField) return;
+
+    const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
+    const draftMessage: DraftMessage = {
+      messageId: null, // no message id because it was not sent yet
+      mentionedUsers: null, // note: mentionedUsers is not kept in this component
+      mentionedMessageTemplate: mentionTemplate,
+      message: messageText
+    };
+    onDraftChange?.(draftMessage);
+  }, [onDraftChange]);
+  const processDraftChangeDebounced = useDebounce(processDraftChangeImmediate, 400);
+
   // #Edit mode
   // for easilly initialize input value from outside, but
   // useEffect(_, [channelUrl]) erase it
@@ -194,7 +235,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
 
   // #Mention & #Edit | Fill message input values
   useEffect(() => {
-    if (isEdit && message?.messageId) {
+    // fork note: allow loading from custom 'draftMessage'
+    if (message) {
       // const textField = document.getElementById(textFieldId);
       const textField = internalRef?.current;
       if (isMentionEnabled && message?.mentionedUsers?.length > 0 && message?.mentionedMessageTemplate?.length > 0) {
@@ -208,9 +250,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           .map((token) => {
             if (token.type === TOKEN_TYPES.mention) {
               const mentionedUser = mentionedUsers.find((user) => user.userId === token.userId);
-              const nickname = `${USER_MENTION_PREFIX}${
-                mentionedUser?.nickname || token.value || stringSet.MENTION_NAME__NO_NAME
-              }`;
+              // fork note: bug fix
+              const nickname = `${USER_MENTION_PREFIX}${mentionedUser?.nickname || token.value || stringSet.MENTION_NAME__NO_NAME}`;
               return renderMentionLabelToString({
                 userId: token.userId,
                 nickname,
@@ -218,7 +259,13 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             }
             return sanitizeString(token.value);
           })
-          .join(' ');
+          // fork note: bug fix
+          .join('');
+
+        // fork note: make sure the userids are updated
+        const userIds = mentionedUsers.map((user) => user.userId)
+        onMentionedUserIdsUpdated(userIds);
+        setMentionedUserIds(userIds);
       } else {
         /* mention disabled */
         try {
@@ -230,6 +277,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       }
       setIsInput(textField?.textContent?.trim().length > 0);
       setHeight();
+      moveCursorToEnd(textField);
     }
   }, [isEdit, message]);
 
@@ -247,6 +295,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       }
     }
     setIsInput(textField.textContent?.trim().length > 0);
+    processDraftChangeDebounced();
   }, [targetStringInfo, isMentionEnabled]);
 
   // #Mention | Replace selected user nickname to the MentionedUserLabel
@@ -297,6 +346,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         setHeight();
         useMentionedLabelDetection();
       }
+      processDraftChangeDebounced();
     }
   }, [mentionSelectedUser, isMentionEnabled]);
 
@@ -368,7 +418,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
 
   const sendMessage = () => {
     const textField = internalRef?.current;
-    if (!isEdit && textField?.textContent) {
+    // fork note: allow "sending" empty message as other things can be added (i.e. attachments)
+    if (!isEdit) {
       const { messageText, mentionTemplate } = extractTextAndMentions(textField.childNodes);
       const params = { message: messageText, mentionTemplate };
       onSendMessage(params);
@@ -396,6 +447,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     channel,
     setIsInput,
     setHeight,
+    customOnPaste,
+    onChange: processDraftChangeImmediate
   });
 
   return (
@@ -406,7 +459,15 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
         disabled ? 'sendbird-message-input-form__disabled' : '',
       ])}
     >
-      <div className={getClassName(['sendbird-message-input', disabled ? 'sendbird-message-input__disabled' : ''])}>
+      {/* fork note: inputAreaPrefix for custom rendering of attachments */}
+      {inputAreaPrefix}
+      <div
+        className={getClassName(['sendbird-message-input', disabled ? 'sendbird-message-input__disabled' : ''])}
+        onClick={() => {
+          // forked note: this is so it focuses on the text input area if you click in the area around it
+          internalRef?.current.focus();
+        }}
+      >
         <div
           id={`${textFieldId}${isEdit ? message?.messageId : ''}`}
           className={`sendbird-message-input--textarea ${textFieldId}`}
@@ -417,6 +478,9 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           // @ts-ignore
           disabled={disabled}
           maxLength={maxLength}
+          // fork note: autoFocus and tabIndex are to allow custom focusing of this div (eg open as soon as it becomes visible)
+          autoFocus={true}
+          tabIndex={0}
           onKeyDown={(e) => {
             const preventEvent = onKeyDown(e);
             if (preventEvent) {
@@ -426,7 +490,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
                 !e.shiftKey
                 && e.key === MessageInputKeys.Enter
                 && !isMobile
-                && internalRef?.current?.textContent?.trim().length > 0
+                // fork note: we may have an unsent attachment that 'enter' should still send
+                // && internalRef?.current?.textContent?.trim().length > 0
                 && e?.nativeEvent?.isComposing !== true
                 /**
                  * NOTE: What isComposing does?
@@ -445,7 +510,18 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
                 if (!isMobileIOS(navigator.userAgent)) {
                   e.preventDefault();
                 }
-                sendMessage();
+                // fork note: allow enter to edit too
+                if (isEdit) {
+                  editMessage();
+                } else {
+                  sendMessage();
+                }
+              }
+              // for note: escape to cancel edit, if editing
+              if (e.key === "Escape") {
+                if (isEdit) {
+                  onCancelEdit?.();
+                }
               }
               if (
                 e.key === MessageInputKeys.Backspace
@@ -473,11 +549,12 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             onStartTyping();
             setIsInput(internalRef?.current?.textContent?.trim().length > 0);
             useMentionedLabelDetection();
+            processDraftChangeDebounced();
           }}
           onPaste={onPaste}
         />
         {/* placeholder */}
-        {(internalRef?.current?.textContent?.length ?? 0) === 0 && (
+        {(internalRef?.current?.textContent?.length ?? 0) === 0 && !inputAreaPrefix && (
           <Label
             className="sendbird-message-input--placeholder"
             type={LabelTypography.BODY_1}
@@ -486,8 +563,11 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
             {placeholder || stringSet.MESSAGE_INPUT__PLACE_HOLDER}
           </Label>
         )}
+        {/* fork note: inputAreaButtons for custom rendering of buttons next to the input */}
+        {inputAreaButtons}
         {/* send icon */}
-        {!isEdit && isInput && (
+        {/* fork note: inputAreaPrefix is used for attachments, so user should be able to send, even if message is empty */}
+        {!isEdit && (isInput || inputAreaPrefix) && (
           <IconButton className="sendbird-message-input--send" height="32px" width="32px" onClick={() => sendMessage()}>
             {renderSendMessageIcon?.() || (
               <Icon


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-7842/implement-fork-changes

This PR follows up on https://github.com/gathertown/sendbird-uikit-react/pull/41 in supporting Mentions on the Gather App. It provides the necessary support for https://github.com/gathertown/gather-town/pull/25766

The changes are around 2 components:
- `MessageInput`: Adds support for all functionalities Gather App needs to make this the main message input component
  - Add support for custom `DraftMessage` (also a new type), which is the data required for an unsent message
  - Add customization for attachments (custom `onPaste` and renderers)
- `SuggestedMentionListView`: UX improvements and made extensible (custom rendering)

## Test Plan

- [x] Test these fork changes without new mentions logic, nothing breaks
- [x] Test these fork changes with new mentions logic, validate that UI works as expected:

### Mentions in input with custom rendering
<img width="375" alt="Screenshot 2024-06-27 at 19 44 55" src="https://github.com/gathertown/sendbird-uikit-react/assets/6392953/ff82904a-373c-4dd0-966b-9056456a486e">

### Mentions in edit with custom rendering

<img width="379" alt="Screenshot 2024-06-27 at 19 48 04" src="https://github.com/gathertown/sendbird-uikit-react/assets/6392953/eb45b3d0-842a-4d62-bb34-5300206ad0fa">

### Attachment preview
<img width="365" alt="Screenshot 2024-06-27 at 19 44 36" src="https://github.com/gathertown/sendbird-uikit-react/assets/6392953/8b9c6be2-17c7-4860-8196-58cd2d5fb0c9">


### CC

@gathertown/chat 
