### PR TITLE
Always render emojis reactions if a custom renderer is passed

### DIFF
--- a/src/ui/MessageContent/index.tsx
+++ b/src/ui/MessageContent/index.tsx
@@ -360,7 +360,8 @@ export default function MessageContent(props: MessageContentProps): ReactElement
             })
           }
           {/* reactions */}
-          {(isReactionEnabledInChannel && message?.reactions?.length > 0) && (
+          {/* [Fork Note] - Always render emoji reactions if a custom render function is provided */}
+          {(isReactionEnabledInChannel && (props.renderEmojiReactions !== null || message?.reactions?.length > 0)) && (
             <div className={getClassName([
               'sendbird-message-content-reactions',
               isMultipleFilesMessage(message)


### PR DESCRIPTION
## Description

This PR addresses an issue with the rendering of emoji reactions in UIKit from our custom renderer.

### Current Behavior
- `renderEmojiReactions` is only called when a message has reactions count greater than 0.
- This prevents optimistic rendering for new reactions.
- Currently, we need to mutate the message to trigger rendering, which is not ideal.

### Proposed Changes
- Modify UIKit to always call `renderEmojiReactions` when a custom renderer is provided.
- Allow the custom renderer to control visibility, regardless of the presence of reactions.

## Test Plan

1. Integrate the local version of UIKit (based on this PR) into gather-browser.
2. Modify `renderEmojiReactions` in MessageContent to add a simple red square div.
3. Verify that the red square renders for messages with no reactions.
4. Test adding and removing reactions to ensure proper rendering in all scenarios.
