### PR TITLE
Fix forwardRef bug in ThreadReplies.

### DIFF
--- a/src/ui/ThreadReplies/index.tsx
+++ b/src/ui/ThreadReplies/index.tsx
@@ -1,4 +1,4 @@
-import React, { RefObject } from 'react';
+import React from 'react';
 import { ThreadInfo } from '@sendbird/chat/message';
 
 import './index.scss';
@@ -19,7 +19,6 @@ export function ThreadReplies(
     threadInfo,
     onClick,
   }: ThreadRepliesProps,
-  ref?: RefObject<HTMLDivElement>,
 ): React.ReactElement {
   const {
     mostRepliedUsers = [],
@@ -38,7 +37,6 @@ export function ThreadReplies(
         onClick(e);
         e?.stopPropagation();
       }}
-      ref={ref}
     >
       <div className="sendbird-ui-thread-replies__user-profiles">
         {mostRepliedUsers.slice(0, 4).map((user) => {
@@ -96,4 +94,4 @@ export function ThreadReplies(
   );
 }
 
-export default React.forwardRef(ThreadReplies);
+export default ThreadReplies;

--- a/src/ui/ThreadReplies/index.tsx
+++ b/src/ui/ThreadReplies/index.tsx
@@ -19,6 +19,7 @@ export function ThreadReplies(
     threadInfo,
     onClick,
   }: ThreadRepliesProps,
+  ref?: RefObject<HTMLDivElement>,
 ): React.ReactElement {
   const {
     mostRepliedUsers = [],
@@ -37,6 +38,7 @@ export function ThreadReplies(
         onClick(e);
         e?.stopPropagation();
       }}
+      ref={ref}
     >
       <div className="sendbird-ui-thread-replies__user-profiles">
         {mostRepliedUsers.slice(0, 4).map((user) => {


### PR DESCRIPTION
## Description

https://github.com/gathertown/sendbird-uikit-react/pull/40 removed a `ref` in a `forwardRef` definition that lead to this error when importing the library to Gather:

```
Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?
```

This lead to failure in some test files. This PR removes the `forwardRef` in `ThreadReplies` to remove the issue, since we don't need it anymore.

## Test Plan

- [x] Build the library with the reverted code (this PR), and validate that the test files succeed without printing errors.
