### PR TITLE
Pass in parentMessage to renderParentMessageInfo

### DIFF
--- a/src/modules/Thread/components/ThreadUI/index.tsx
+++ b/src/modules/Thread/components/ThreadUI/index.tsx
@@ -21,7 +21,7 @@ import { SendableMessageType } from '../../../../utils';
 
 export interface ThreadUIProps {
   renderHeader?: () => React.ReactElement;
-  renderParentMessageInfo?: () => React.ReactElement;
+  renderParentMessageInfo?: (message: SendableMessageType) => React.ReactElement;
   renderMessage?: (props: {
     message: SendableMessageType,
     chainTop: boolean,

--- a/src/modules/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
+++ b/src/modules/Thread/components/ThreadUI/useMemorizedParentMessageInfo.tsx
@@ -7,7 +7,7 @@ import { SendableMessageType } from '../../../../utils';
 export interface UseMemorizedParentMessageInfoProps {
   parentMessage: SendableMessageType;
   parentMessageState: ParentMessageStateTypes;
-  renderParentMessageInfo?: () => React.ReactElement;
+  renderParentMessageInfo?: (message: SendableMessageType) => React.ReactElement;
   renderParentMessageInfoPlaceholder?: (type: ParentMessageStateTypes) => React.ReactElement;
 }
 
@@ -58,7 +58,7 @@ const useMemorizedParentMessageInfo = ({
     }
   } else if (parentMessageState === ParentMessageStateTypes.INITIALIZED) {
     if (typeof renderParentMessageInfo === 'function') {
-      return renderParentMessageInfo();
+      return renderParentMessageInfo(parentMessage);
     }
   }
   return null;


### PR DESCRIPTION
## Description
We want to pass in this to renderParentMessageInfo so that renderParentMessageInfo always has the same message object reference as the one in ThreadContext. Without this, there was the parent message component wasn't updating correctly because the `message` obj passed into the Context is not the same reference that gets updated in the context

## Test Plan
now the parent message component updates correctly! 