### PR TITLE
Create useSendFileMessageCallbackV2

### DIFF
--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -58,6 +58,7 @@ export interface ThreadProviderInterface extends ThreadProviderProps, ThreadCont
   toggleReaction: (message, key, isReacted) => void;
   sendMessage: (props: SendMessageParams) => void;
   sendFileMessage: (file: File, quoteMessage?: SendableMessageType) => Promise<FileMessage>;
+  // Fork note: need to be able to pass in params to sendFileMessage, not just `file` so made a copy
   sendFileMessageV2: (params: FileMessageCreateParams, quoteMessage?: SendableMessageType) => Promise<FileMessage>;
   sendVoiceMessage: (file: File, duration: number, quoteMessage?: SendableMessageType) => void;
   sendMultipleFilesMessage: (files: Array<File>, quoteMessage?: SendableMessageType) => Promise<MultipleFilesMessage>,

--- a/src/modules/Thread/context/ThreadProvider.tsx
+++ b/src/modules/Thread/context/ThreadProvider.tsx
@@ -33,6 +33,7 @@ import { PublishingModuleType, useSendMultipleFilesMessage } from './hooks/useSe
 import { SendableMessageType } from '../../../utils';
 import { useThreadFetchers } from './hooks/useThreadFetchers';
 import type { OnBeforeDownloadFileMessageType } from '../../GroupChannel/context/GroupChannelProvider';
+import useSendFileMessageCallbackV2 from './hooks/useSendFileMessageV2';
 
 export type ThreadProviderProps = {
   children?: React.ReactElement;
@@ -57,6 +58,7 @@ export interface ThreadProviderInterface extends ThreadProviderProps, ThreadCont
   toggleReaction: (message, key, isReacted) => void;
   sendMessage: (props: SendMessageParams) => void;
   sendFileMessage: (file: File, quoteMessage?: SendableMessageType) => Promise<FileMessage>;
+  sendFileMessageV2: (params: FileMessageCreateParams, quoteMessage?: SendableMessageType) => Promise<FileMessage>;
   sendVoiceMessage: (file: File, duration: number, quoteMessage?: SendableMessageType) => void;
   sendMultipleFilesMessage: (files: Array<File>, quoteMessage?: SendableMessageType) => Promise<MultipleFilesMessage>,
   resendMessage: (failedMessage: SendableMessageType) => void;
@@ -193,6 +195,15 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
     pubSub,
     threadDispatcher,
   });
+  const sendFileMessageV2 = useSendFileMessageCallbackV2({
+    currentChannel,
+    onBeforeSendFileMessage,
+  }, {
+    logger,
+    eventHandlers,
+    pubSub,
+    threadDispatcher,
+  });
   const sendVoiceMessage = useSendVoiceMessageCallback({
     currentChannel,
     onBeforeSendVoiceMessage,
@@ -257,6 +268,7 @@ export const ThreadProvider = (props: ThreadProviderProps) => {
         toggleReaction,
         sendMessage,
         sendFileMessage,
+        sendFileMessageV2,
         sendVoiceMessage,
         sendMultipleFilesMessage,
         resendMessage,

--- a/src/modules/Thread/context/hooks/useSendFileMessageV2.ts
+++ b/src/modules/Thread/context/hooks/useSendFileMessageV2.ts
@@ -1,0 +1,90 @@
+import { useCallback } from 'react';
+import { GroupChannel } from '@sendbird/chat/groupChannel';
+import { FileMessage, FileMessageCreateParams } from '@sendbird/chat/message';
+
+import { CustomUseReducerDispatcher, Logger } from '../../../../lib/SendbirdState';
+import { ThreadContextActionTypes } from '../dux/actionTypes';
+import topics, { SBUGlobalPubSub } from '../../../../lib/pubSub/topics';
+import { scrollIntoLast } from '../utils';
+import { SendableMessageType } from '../../../../utils';
+import { PublishingModuleType } from './useSendMultipleFilesMessage';
+import { SCROLL_BOTTOM_DELAY_FOR_SEND } from '../../../../utils/consts';
+import { SBUEventHandlers } from '../../../../lib/types';
+
+interface DynamicProps {
+  currentChannel: GroupChannel;
+  onBeforeSendFileMessage?: (file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams;
+}
+interface StaticProps {
+  logger: Logger;
+  pubSub: SBUGlobalPubSub;
+  threadDispatcher: CustomUseReducerDispatcher;
+  eventHandlers?: SBUEventHandlers
+}
+
+interface LocalFileMessage extends FileMessage {
+  localUrl: string;
+  file: File;
+}
+
+export type SendFileMessageFunctionTypeV2 = (params: FileMessageCreateParams, quotedMessage?: SendableMessageType) => Promise<FileMessage>;
+
+export default function useSendFileMessageCallbackV2({
+  currentChannel,
+  onBeforeSendFileMessage,
+}: DynamicProps, {
+  logger,
+  eventHandlers,
+  pubSub,
+  threadDispatcher,
+}: StaticProps): SendFileMessageFunctionTypeV2 {
+  const sendMessage = useCallback((params: FileMessageCreateParams, quoteMessage): Promise<FileMessage> => {
+    return new Promise((resolve, reject) => {
+        if (quoteMessage) {
+          params.isReplyToChannel = true;
+          params.parentMessageId = quoteMessage.messageId;
+        }
+      logger.info('Thread | useSendFileMessageCallback: Sending file message start.', params);
+
+      currentChannel?.sendFileMessage(params)
+        .onPending((pendingMessage) => {
+          threadDispatcher({
+            type: ThreadContextActionTypes.SEND_MESSAGE_START,
+            payload: {
+              /* pubSub is used instead of messagesDispatcher
+              to avoid redundantly calling `messageActionTypes.SEND_MESSAGE_START` */
+              // TODO: remove data pollution
+              message: {
+                ...pendingMessage,
+                requestState: 'pending',
+                isUserMessage: pendingMessage.isUserMessage,
+                isFileMessage: pendingMessage.isFileMessage,
+                isAdminMessage: pendingMessage.isAdminMessage,
+                isMultipleFilesMessage: pendingMessage.isMultipleFilesMessage,
+              },
+            },
+          });
+          setTimeout(() => scrollIntoLast(), SCROLL_BOTTOM_DELAY_FOR_SEND);
+        })
+        .onFailed((error, message) => {
+          logger.info('Thread | useSendFileMessageCallback: Sending file message failed.', { message, error });
+          eventHandlers?.request?.onFailed?.(error);
+          threadDispatcher({
+            type: ThreadContextActionTypes.SEND_MESSAGE_FAILURE,
+            payload: { message, error },
+          });
+          reject(error);
+        })
+        .onSucceeded((message: FileMessage) => {
+          logger.info('Thread | useSendFileMessageCallback: Sending file message succeeded.', message);
+          pubSub.publish(topics.SEND_FILE_MESSAGE, {
+            channel: currentChannel,
+            message: message,
+            publishingModules: [PublishingModuleType.THREAD],
+          });
+          resolve(message);
+        });
+    });
+  }, [currentChannel]);
+  return sendMessage;
+}


### PR DESCRIPTION
## Description
This makes a copy of https://github.com/gathertown/sendbird-uikit-react/blob/main/src/modules/Thread/context/hooks/useSendFileMessage.ts but changes the return type to be `(params: FileMessageCreateParams, quotedMessage?: SendableMessageType) => Promise<FileMessage>;` instead of `(file: File, quotedMessage?: SendableMessageType) => FileMessageCreateParams` in order to allow passing in custom params like `data` which is used to augment file previews!

## Test Plan
tested sending file messages in threads, and the preview works
![Screenshot 2024-07-03 at 2 49 54 PM](https://github.com/gathertown/sendbird-uikit-react/assets/51099886/8ed6503d-e334-41ff-b4d8-6c6d9f4c1a55)

