### PR TITLE
Fix draft not clearing after sending message.

### DIFF
--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -429,6 +429,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       textField.focus();
       setIsInput(false);
       setHeight();
+      // fork note: make sure draft is cleared
+      processDraftChangeImmediate();
     }
   };
   const isEditDisabled = !internalRef?.current?.textContent?.trim();
@@ -440,6 +442,8 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
       const params = { messageId, message: messageText, mentionTemplate };
       onUpdateMessage(params);
       resetInput(internalRef);
+      // fork note: make sure draft is cleared
+      processDraftChangeImmediate();
     }
   };
   const onPaste = usePaste({


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-8037/already-sent-message-saved-in-draft

Fix draft not clearing after sending message by making sure the draft callback is called after the input is cleared.

## Test Plan

- [x] Test Gather with a build using this code; Validate that after sending messages, the draft clears properly.

