### PR TITLE
Implement custom MessageInputCallback imperative handler.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,14 @@ export interface DraftMessage {
   mentionedMessageTemplate?: string | null;
 }
 
+// Define the interface for the MessageInput instance
+export interface MessageInputCallbackRef {
+  sendMessage: () => void;
+  saveMessageEdit: () => void;
+  cancelMessageEdit: () => void;
+  mentionInputDetection: () => void;
+}
+
 export interface SendBirdProviderConfig {
   logLevel?: 'debug' | 'warning' | 'error' | 'info' | 'all' | Array<string>;
   userMention?: {


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-8016/implement-new-message-input-style

<img width="378" alt="Screenshot 2024-07-16 at 17 38 32" src="https://github.com/user-attachments/assets/62d8cc99-8c3b-46d0-b890-1ff2238c710f">

In order to fully support Gather's new input component, we need a way to make immediate callbacks to a few important lifecycle handlers that live within the `MessageInput` component. This PR exposes those.

## Test Plan

- [x] Build the library with these changes; Use the new code in Gather; Validate all handlers work.
