### PR TITLE
Fix messages not fetching when scrolling up

### DIFF
--- a/src/hooks/useOnScrollReachedEndDetector/index.ts
+++ b/src/hooks/useOnScrollReachedEndDetector/index.ts
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import { SCROLL_BUFFER } from '../../utils/consts';
 import { isAboutSame } from '../../modules/Channel/context/utils';
 import { usePreservedCallback } from '@sendbird/uikit-tools';
-import { useThrottleCallback } from '../useThrottleCallback';
+import { throttle, useThrottleCallback } from '../useThrottleCallback';
 
 const BUFFER_DELAY = 100;
 
@@ -37,4 +37,42 @@ export function useOnScrollPositionChangeDetector(
   });
 
   return useThrottleCallback(cb, BUFFER_DELAY, { trailing: true });
+}
+
+// fork note: this reverts changes from https://github.com/sendbird/sendbird-uikit-react/pull/1094/
+// because our custom scroll bug fixes has deviated too much from upstream
+export function useOnScrollPositionChangeDetectorWithRef(
+  scrollRef: React.RefObject<HTMLDivElement>,
+  params: UseOnScrollReachedEndDetectorParams,
+) {
+  const _params = useRef(params);
+  _params.current = params;
+
+  useLayoutEffect(() => {
+    const elem = scrollRef.current;
+    if (elem) {
+      const callback = throttle(
+        () => {
+          const { scrollTop, scrollHeight, clientHeight } = elem;
+
+          const event: onPositionEvent = {
+            distanceFromBottom: scrollHeight - scrollTop - clientHeight,
+          };
+
+          if (_params.current.onReachedTop && isAboutSame(scrollTop, 0, SCROLL_BUFFER)) {
+            _params.current.onReachedTop(event);
+          } else if (_params.current.onReachedBottom && isAboutSame(scrollHeight, clientHeight + scrollTop, SCROLL_BUFFER)) {
+            _params.current.onReachedBottom(event);
+          } else if (_params.current.onInBetween) {
+            _params.current.onInBetween(event);
+          }
+        },
+        BUFFER_DELAY,
+        { trailing: true },
+      );
+
+      elem.addEventListener('scroll', callback);
+      return () => elem.removeEventListener('scroll', callback);
+    }
+  }, [scrollRef.current]);
 }

--- a/src/modules/GroupChannel/context/hooks/useMessageListScroll.tsx
+++ b/src/modules/GroupChannel/context/hooks/useMessageListScroll.tsx
@@ -1,5 +1,6 @@
 import { DependencyList, useLayoutEffect, useRef, useState } from 'react';
 import pubSubFactory from '../../../../lib/pubSub';
+import { useOnScrollPositionChangeDetectorWithRef } from '../../../../hooks/useOnScrollReachedEndDetector';
 
 /**
  * You can pass the resolve function to scrollPubSub, if you want to catch when the scroll is finished.
@@ -95,6 +96,24 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto', deps: Dependen
       unsubscribes.forEach(({ remove }) => remove());
     };
   }, [behavior]);
+  
+  // fork note: this reverts changes from https://github.com/sendbird/sendbird-uikit-react/pull/1094/
+  // because our custom scroll bug fixes has deviated too much from upstream
+  // Update data by scroll events
+  useOnScrollPositionChangeDetectorWithRef(scrollRef, {
+    onReachedTop({ distanceFromBottom }) {
+      setIsScrollBottomReached(false);
+      scrollDistanceFromBottomRef.current = distanceFromBottom;
+    },
+    onInBetween({ distanceFromBottom }) {
+      setIsScrollBottomReached(false);
+      scrollDistanceFromBottomRef.current = distanceFromBottom;
+    },
+    onReachedBottom({ distanceFromBottom }) {
+      setIsScrollBottomReached(true);
+      scrollDistanceFromBottomRef.current = distanceFromBottom;
+    },
+  });
 
   return {
     scrollRef,

--- a/src/modules/GroupChannel/context/hooks/usePreventDuplicateRequest.ts
+++ b/src/modules/GroupChannel/context/hooks/usePreventDuplicateRequest.ts
@@ -1,0 +1,32 @@
+import { useRef } from 'react';
+
+// fork note: this reverts changes from https://github.com/sendbird/sendbird-uikit-react/pull/1094/
+// because our custom scroll bug fixes has deviated too much from upstream
+
+/**
+ * @description This hook is designed to prevent scroll flickering caused by duplicate calls of onEndReached and onTopReached.
+ * It controls the loading of messages to ensure a single request for message retrieval.
+ * */
+export const usePreventDuplicateRequest = () => {
+  const context = useRef({ locked: false, count: 0 }).current;
+
+  return {
+    lock() {
+      context.locked = true;
+    },
+    async run(callback: any) {
+      if (context.locked && context.count > 0) return;
+
+      try {
+        context.count++;
+        await callback();
+      } catch {
+        // noop
+      }
+    },
+    release() {
+      context.locked = false;
+      context.count = 0;
+    },
+  };
+};


### PR DESCRIPTION
## Description
Unfortunately our fork fixes for scroll issues made by @awlui has deviated too much from upstream that we're unable to merge conflict https://github.com/sendbird/sendbird-uikit-react/pull/1094/ correctly

so instead, this reverts some of the changes from that PR and adds back the messages fetching when scrolling to top

## Test Plan
- when loading in a channel with 30+ messages, it's initialized to the bottom
- scrolling up loads more messages
- clicking "scroll to bottom" scrolls to bottom
- container scrolls to bottom when new messages come in and you're at the bottom
- container shows "new message" if you are not scrolled to the bottom and a new message comes in
- sending a message scrolls to bottom