### PR TITLE
Port over missing changes for scrolling behavior revert

### DIFF
--- a/src/modules/GroupChannel/context/hooks/useMessageListScroll.tsx
+++ b/src/modules/GroupChannel/context/hooks/useMessageListScroll.tsx
@@ -1,4 +1,4 @@
-import { DependencyList, useLayoutEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import pubSubFactory from '../../../../lib/pubSub';
 import { useOnScrollPositionChangeDetectorWithRef } from '../../../../hooks/useOnScrollReachedEndDetector';
 
@@ -25,21 +25,18 @@ export type ScrollTopicUnion =
       };
     };
 
-export function useMessageListScroll(behavior: 'smooth' | 'auto', deps: DependencyList = []) {
+export function useMessageListScroll(behavior: 'smooth' | 'auto') {
   const scrollRef = useRef<HTMLDivElement>(null);
   const scrollPositionRef = useRef(0);
   const scrollDistanceFromBottomRef = useRef(0);
 
   const [scrollPubSub] = useState(() => pubSubFactory<ScrollTopics, ScrollTopicUnion>({ publishSynchronous: true }));
   const [isScrollBottomReached, setIsScrollBottomReached] = useState(true);
-
-  // SideEffect: Reset scroll state
-  useLayoutEffect(() => {
-    scrollPositionRef.current = 0;
+  // If there is no area to scroll, it is considered as scroll bottom reached.
+  if (isScrollBottomReached === false && scrollRef.current && scrollRef.current.scrollHeight <= scrollRef.current.clientHeight) {
     scrollDistanceFromBottomRef.current = 0;
     setIsScrollBottomReached(true);
-    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-  }, deps);
+  }
 
   useLayoutEffect(() => {
     const unsubscribes: { remove(): void }[] = [];
@@ -47,10 +44,7 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto', deps: Dependen
     unsubscribes.push(
       scrollPubSub.subscribe('scrollToBottom', ({ resolve, animated }) => {
         runCallback(() => {
-          if (!scrollRef.current) {
-            if (resolve) resolve();
-            return;
-          }
+          if (!scrollRef.current) return;
 
           if (scrollRef.current.scroll) {
             scrollRef.current.scroll({ top: scrollRef.current.scrollHeight, behavior: getScrollBehavior(behavior, animated) });
@@ -82,7 +76,7 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto', deps: Dependen
           // Update data by manual update
           scrollDistanceFromBottomRef.current = Math.max(0, scrollHeight - scrollTop - clientHeight);
 
-          // This is commented out because we don't want the bottom reached 
+          // This is commented out because we don't want the bottom reached
           // computation to trigger on content size change. useOnScrollPositionChangeDetectorWithRef will
           // trigger the computation on true scrolling.
           // setIsScrollBottomReached(scrollDistanceFromBottomRef.current === 0);
@@ -96,7 +90,7 @@ export function useMessageListScroll(behavior: 'smooth' | 'auto', deps: Dependen
       unsubscribes.forEach(({ remove }) => remove());
     };
   }, [behavior]);
-  
+
   // fork note: this reverts changes from https://github.com/sendbird/sendbird-uikit-react/pull/1094/
   // because our custom scroll bug fixes has deviated too much from upstream
   // Update data by scroll events


### PR DESCRIPTION
## Description
https://github.com/gathertown/sendbird-uikit-react/pull/51 was missing some LoC from reverting https://github.com/sendbird/sendbird-uikit-react/pull/1094 that's potentially triggering some weird scroll behaviors

## Test Plan
i couldn't repro the weird scroll behaviors locally like the "Latest messages" button showing unnecessary but at least the previous test plan still passes with these changes

- when loading in a channel with 30+ messages, it's initialized to the bottom
- scrolling up loads more messages
- clicking "scroll to bottom" scrolls to bottom
- container scrolls to bottom when new messages come in and you're at the bottom
- container shows "new message" if you are not scrolled to the bottom and a new message comes in
- sending a message scrolls to bottom