### PR TITLE
Improve link parsing and pasting

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
     "@sendbird/uikit-tools": "0.0.1-alpha.76",
     "css-vars-ponyfill": "^2.3.2",
     "date-fns": "^2.16.1",
-    "dompurify": "^3.0.1"
+    "dompurify": "^3.0.1",
+    "linkify-html": "^4.1.3",
+    "linkifyjs": "^4.1.3"
   },
   "bugs": {
     "url": "https://community.sendbird.com"

--- a/src/modules/Message/utils/tokens/tokenize.ts
+++ b/src/modules/Message/utils/tokens/tokenize.ts
@@ -10,6 +10,8 @@ import {
   UndeterminedToken,
 } from './types';
 
+import * as linkify from 'linkifyjs';
+
 /**
  * /\[(.*?)\]\((.*?)\) is for url.
  * /\*\*(.*?)\*\* for bold.
@@ -65,18 +67,19 @@ export function identifyMentions({
 }
 
 export function identifyUrlsAndStrings(token: Token[]): Token[] {
-  const URL_REG = /(?:https?:\/\/|www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.(xn--)?[a-z]{2,20}\b([-a-zA-Z0-9@:%_+[\],.~#?&/=]*[-a-zA-Z0-9@:%_+~#?&/=])*/g;
   const results: Token[] = token.map((token) => {
     if (token.type !== TOKEN_TYPES.undetermined) {
       return token;
     }
     const { value = '' } = token;
 
-    const matches = Array.from(value.matchAll(URL_REG));
+    // Fork note - use linkifyjs to find urls in the string
+    const matches = linkify.find(value);
+
     const founds = matches.map((value) => {
-      const text = value[0];
-      const start = value.index ?? 0;
-      const end = start + text.length;
+      const text = value.value;
+      const start = value.start ?? 0;
+      const end = value.end;
       return { text, start, end };
     });
 

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -51,11 +51,7 @@ export function usePaste({
       if (!hasMention(pasteNode)) {
         // to preserve space between words
         const text = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
-        // fork note - encodeURIComponent is used to preserve & and other special characters
-        const encodedText = encodeURIComponent(sanitizeString(text));
-        document.execCommand('insertHTML', false, encodedText);
-        // fork note - decodeURIComponent is used to preserve & and other special characters
-        ref.current.innerText = decodeURIComponent(ref.current.innerText);
+        document.execCommand('insertHTML', false, sanitizeString(text));
         pasteNode.remove();
         setIsInput(true);
         setHeight();

--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -51,7 +51,11 @@ export function usePaste({
       if (!hasMention(pasteNode)) {
         // to preserve space between words
         const text = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
-        document.execCommand('insertHTML', false, sanitizeString(text));
+        // fork note - encodeURIComponent is used to preserve & and other special characters
+        const encodedText = encodeURIComponent(sanitizeString(text));
+        document.execCommand('insertHTML', false, encodedText);
+        // fork note - decodeURIComponent is used to preserve & and other special characters
+        ref.current.innerText = decodeURIComponent(ref.current.innerText);
         pasteNode.remove();
         setIsInput(true);
         setHeight();

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -558,6 +558,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
           contentEditable={!disabled}
           role="textbox"
           aria-label="Text Input"
+          spellCheck="true"
           ref={externalRef}
           // @ts-ignore
           disabled={disabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,6 +1939,8 @@ __metadata:
     jest-environment-jsdom: 29.5.0
     jest-extended: ^3.2.4
     jsdom: ^20.0.0
+    linkify-html: ^4.1.3
+    linkifyjs: ^4.1.3
     plop: ^2.5.3
     postcss: ^8.3.5
     postcss-rtlcss: ^5.3.0
@@ -10856,6 +10858,22 @@ __metadata:
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
   checksum: 0c37f9f7fa212b38912b7145e1cd16a5f3cd34d782441c3e6ca653485d326f58b3caccda66efce1c5812bde4961bbde3374fae4b0d11bf1226152337f3894aa5
+  languageName: node
+  linkType: hard
+
+"linkify-html@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "linkify-html@npm:4.1.3"
+  peerDependencies:
+    linkifyjs: ^4.0.0
+  checksum: 1d9b6a5e85d75ccb581693382d543e76ff54acb332ce4de1dfb4ade0f8e85c1050d4db337e9e73d6ab65fe4f25fcf83762dda19984132d11c9a1256ace31f392
+  languageName: node
+  linkType: hard
+
+"linkifyjs@npm:^4.1.3":
+  version: 4.1.3
+  resolution: "linkifyjs@npm:4.1.3"
+  checksum: 023d467499a717a49ebbfa256a80cb2811a3b038ff2593e5be0fb8a4715b0a63bf80c571838e19e120833d5b9874464f3a1448965c8eebbde8c19458b3a6c6e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-6478/links-with-dont-linkify

Currently, the link parsing is done using a Regex, this is a similar approach that generally works well, but doesn't sufficiently handle edge cases.

Additionally, links that are pasted into the text input aren't always pasted correctly and can end up with invalid symbols.

### Changes made
- Introduce linkifyjs to handle link parsing from strings
- Encode and then decode pasted urls into the chat input 

## Test Plan

- [x] **Manually test link parsing**
1. Paste the following text into the chat input
https://en.wikipedia.org/wiki/Rain_(given_name)
2. Press send
3. Observe that the link is correctly parsed, clickable and valid.

- [x] **Manually test link pasting**
1. Paste the following text into the chat input
https://www.techempower.com/benchmarks/#hw=ph&test=query&section=data-r22  
2. Observe that it doesn't get altered incorrectly
3. Paste normal text into the chat input
4. Observe it gets added to the input correctly
5. Copy and paste an image into the input
6. Observe that it gets added as an image preview correctly


### CC

@liamuk 
