### PR TITLE
Fix pasting contents not working for some cases.

### DIFF
--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -49,9 +49,16 @@ export function usePaste({
       pasteNode.innerHTML = clean;
       // does not have mention, continue as normal
       if (!hasMention(pasteNode)) {
-        // to preserve space between words
-        const text = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
-        document.execCommand('insertHTML', false, sanitizeString(text));
+        // fork notes: sometimes the pasted contents are not available as children, but rather in the node itself
+        // for more info, see APP-8144
+        if (pasteNode.children.length > 0) {
+          // to preserve space between words
+          const text = extractTextFromNodes(Array.from(pasteNode.children) as HTMLSpanElement[]);
+          document.execCommand('insertHTML', false, sanitizeString(text));
+        } else {
+          const text = pasteNode.innerText;
+          document.execCommand('insertHTML', false, sanitizeString(text));
+        }
         pasteNode.remove();
         setIsInput(true);
         setHeight();


### PR DESCRIPTION
## Description

Linear: https://linear.app/gather-town/issue/APP-8144/chatv2-cannot-paste-some-kinds-of-content

Fix pasting contents not working for some cases.

## Test Plan

- [x] Copy link automatically from WebStorm plugin: validate pasting works as expected by triggering the new flow
- [x] (Backwards-compatibility): Paste regular text: validate still works
- [x] (Backwards-compatibility): Paste from Chrome URL: validate still works
- [x] (Backwards-compatibility): Paste from another Gather message: validate still works
- [x] (Backwards-compatibility): Paste from message input itself: validate still works