### PR TITLE
Allow initial channels to be passed to ChannelListProvider

### DIFF
--- a/src/modules/ChannelList/context/ChannelListProvider.tsx
+++ b/src/modules/ChannelList/context/ChannelListProvider.tsx
@@ -94,11 +94,15 @@ export interface ChannelListProviderProps {
   isTypingIndicatorEnabled?: boolean;
   isMessageReceiptStatusEnabled?: boolean;
   reconnectOnIdle?: boolean;
+  // Fork note - allow user to pass initial channels
+  initialChannels?: GroupChannel[];
 }
 
 export interface ChannelListProviderInterface extends ChannelListProviderProps {
   initialized: boolean;
   loading: boolean;
+  // Fork note - silentLoading when channels are loading, but no spinner is shown
+  silentLoading: boolean;
   error: SendbirdError | null;
   allChannels: GroupChannel[];
   currentChannel: GroupChannel | null;
@@ -155,7 +159,8 @@ const ChannelListProvider: React.FC<ChannelListProviderProps> = (props: ChannelL
 
   const sdkIntialized = sdkStore?.initialized;
 
-  const [channelListStore, channelListDispatcher] = useReducer(channelListReducers, channelListInitialState);
+  // Fork note - allow user to pass initial channels
+  const [channelListStore, channelListDispatcher] = useReducer(channelListReducers, { ...channelListInitialState, allChannels: props.initialChannels ?? [] });
   const { currentChannel } = channelListStore;
 
   const [channelSource, setChannelSource] = useState<GroupChannelListQuerySb | null>(null);

--- a/src/modules/ChannelList/dux/initialState.ts
+++ b/src/modules/ChannelList/dux/initialState.ts
@@ -4,6 +4,7 @@ import type { GroupChannel, GroupChannelListQuery } from '@sendbird/chat/groupCh
 export interface ChannelListInitialStateType {
   initialized: boolean;
   loading: boolean;
+  silentLoading: boolean;
   error: SendbirdError | null;
   allChannels: GroupChannel[];
   currentChannel: null | GroupChannel;
@@ -16,6 +17,7 @@ const initialState: ChannelListInitialStateType = {
   // we might not need this initialized state -> should remove
   initialized: false,
   loading: true,
+  silentLoading: false,
   error: null,
   allChannels: [],
   currentChannel: null,

--- a/src/modules/ChannelList/dux/reducers.ts
+++ b/src/modules/ChannelList/dux/reducers.ts
@@ -14,7 +14,8 @@ export default function channelListReducer(
     match(action)
       .with({ type: channelListActions.INIT_CHANNELS_START }, ({ payload }) => ({
         ...state,
-        loading: true,
+        loading: !state.allChannels.length,
+        silentLoading: !!state.allChannels.length,
         error: null,
         currentUserId: payload.currentUserId,
       }))
@@ -27,6 +28,7 @@ export default function channelListReducer(
           ...state,
           initialized: true,
           loading: false,
+          silentLoading: false,
           error: null,
           allChannels: channelList,
           disableAutoSelect,
@@ -39,15 +41,17 @@ export default function channelListReducer(
         return {
           ...state,
           loading: false,
+          silentLoading: false,
           error: null,
           allChannels: channelList,
           currentChannel,
         };
       })
-      .with({ type: channelListActions.FETCH_CHANNELS_START }, (action) => {
+      .with({ type: channelListActions.FETCH_CHANNELS_START }, () => {
         return {
           ...state,
           loading: true,
+          silentLoading: false,
           error: null,
         };
       })


### PR DESCRIPTION
## Description

Allow initial channels to be passed in a ChannelListProvider, this allows us to have an external store of channels that we can use to reduce jarring loading spinners.

If initialChannels are provided, silently load the channels in the background, without showing the loading state

## Test Plan

1. Load a dev version into gather-town
2. Pass some GroupChannels to ChannelListProvider
3. Observe the channels are shown immediately and no loading spinner is shown.
