### PR TITLE
Improve mention UX

### DIFF
--- a/src/ui/MessageInput/hooks/usePaste/index.ts
+++ b/src/ui/MessageInput/hooks/usePaste/index.ts
@@ -20,13 +20,13 @@ export function usePaste({
   setHeight,
   channel,
   setMentionedUsers,
-  customOnPaste,
+  customOnFilePaste,
   onChange,
 }: DynamicProps): (e: React.ClipboardEvent<HTMLDivElement>) => void {
   return useCallback((e) => {
-    if (customOnPaste && customOnPaste(e)) {
-      // custom logic already handled input, exit here
-      return;
+    // fork notes: handle file paste explicitly
+    if (customOnFilePaste && e.clipboardData.items.length > 0) {
+      return customOnFilePaste?.(e);
     }
 
     e.preventDefault();
@@ -83,7 +83,7 @@ export function usePaste({
     setIsInput(true);
     setHeight();
     onChange?.();
-  }, [ref, setIsInput, setHeight, channel, setMentionedUsers, customOnPaste]);
+  }, [ref, setIsInput, setHeight, channel, setMentionedUsers, customOnFilePaste]);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#dragging_links

--- a/src/ui/MessageInput/hooks/usePaste/types.ts
+++ b/src/ui/MessageInput/hooks/usePaste/types.ts
@@ -17,7 +17,7 @@ export type DynamicProps = {
   /* fork notes: custom callbacks */
   // called before any uikit code when there's a paste event.
   // if callback returns true, uikit's code will not be executed
-  customOnPaste?: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
+  customOnFilePaste?: (e: React.ClipboardEvent<HTMLDivElement>) => boolean;
   // called if there was any change to the value
   onChange?: () => void;
 };

--- a/src/ui/MessageInput/index.tsx
+++ b/src/ui/MessageInput/index.tsx
@@ -159,7 +159,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     inputAreaPrefix,
     inputAreaButtons,
     onDraftChange,
-    onPaste: customOnPaste,
+    onPaste: customOnFilePaste,
   } = props;
 
   const internalRef = (externalRef && 'current' in externalRef) ? externalRef : null;
@@ -493,7 +493,7 @@ const MessageInput = React.forwardRef<HTMLInputElement, MessageInputProps>((prop
     channel,
     setIsInput,
     setHeight,
-    customOnPaste,
+    customOnFilePaste,
     onChange: processDraftChangeImmediate,
   });
 

--- a/src/ui/MessageInput/utils.ts
+++ b/src/ui/MessageInput/utils.ts
@@ -48,5 +48,6 @@ export function extractTextAndMentions(childNodes: NodeListOf<ChildNode>) {
       mentionTemplate += textContent;
     }
   });
-  return { messageText, mentionTemplate };
+  // Fork-note - trim the messageText and mentionTemplate to remove leading and trailing whitespaces
+  return { messageText: messageText.trim(), mentionTemplate: mentionTemplate.trim() };
 }


### PR DESCRIPTION
## Description

Polish the mention functionality of chat.

### Changes made
- Only provide a custom paste function for copy and paste files, otherwise, let SendBird's native code handle the operation.
- Trim whitespace from messages

## Test Plan

1. Load this version of UIKIt in Gather Town
2. Pass a custom customOnFilePaste function
3. Observe that the function is called, when pasting files and not called, when just pasting text
4. Observe that pasting mentions now works
5. Add mention to input
6. Observe that once it's sent, any trailing whitespace is stripped
